### PR TITLE
Fix metrics logical comparison and model save utility

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -28,7 +28,8 @@ def get_prf(true_class, total_class, pred_class, nan_option = 'mean', nan_value 
     rec_fix = np.nan_to_num(rec)
 
   f1 = 2/(pre_fix**(-1) + rec_fix**(-1))
-  f1[(pre_fix) == 0 & (rec_fix == 0)] = 0
+  # Ensure logical comparison uses proper precedence
+  f1[(pre_fix == 0) & (rec_fix == 0)] = 0
 
   if nan_option == 'value':
     f1[total_class==0] = np.nan

--- a/model_RF.py
+++ b/model_RF.py
@@ -253,10 +253,10 @@ class RFmodel():
 
 
 def save_single(model, path, name = 'single'):
-    #only saves the current new forest (newly added one)
+    """Save a single RandomForest model to disk."""
     filename = 'rf_' + name
     with open(path + '/' + filename, 'wb') as file:
-      pickle.dump(self.model, file)
+        pickle.dump(model, file)
     # pickle.dump(model, open(path + '/' + filename, 'wb'))
 
 


### PR DESCRIPTION
## Summary
- fix operator precedence issue when zeroing F1 scores
- correct standalone `save_single` helper to use passed model

## Testing
- `python3 -m py_compile metrics.py model_RF.py`

------
https://chatgpt.com/codex/tasks/task_e_686d83b5e2588325b44f3094eb70edbc