### PR TITLE
Fix residual classification bug

### DIFF
--- a/main_model_GF_gpf.ipynb
+++ b/main_model_GF_gpf.ipynb
@@ -1212,7 +1212,7 @@
     "        georf.fit(Xtrain_L1, ytrain, Xtrain_group, val_ratio = VAL_RATIO)\n",
     "        #preidct\n",
     "        ypred_train_L1 = georf.predict(Xtrain_L1, Xtrain_group)\n",
-    "        error = ytrain - ypred_train_L1  # calculate error for L1 predictions\n",
+    "        error = (ytrain != ypred_train_L1).astype(int)  # misclassification indicator\n",
     "        \n",
     "        # reindex Xtrain_L2 and Xtest_L2 to avoid the index error\n",
     "        georf_l2 = GeoRF(min_model_depth = MIN_DEPTH, max_model_depth = MAX_DEPTH, n_jobs = N_JOBS, max_depth=5)  # define L2 GeoRF\n",

--- a/model_RF.py
+++ b/model_RF.py
@@ -93,14 +93,14 @@ class RFmodel():
     # else:
 
   def predict(self, X, prob = False):
-    #prob here is aggregated probability (does not sum to 1 without normalizing)
+    """Return predicted labels or probabilities."""
 
-    y_pred = self.model.predict_proba(X)
+    y_pred_prob = self.model.predict_proba(X)
 
-    if not prob:
-      y_pred = np.argmax(y_pred, axis=1)
+    if prob:
+      return y_pred_prob
 
-    return y_pred
+    return self.model.predict(X)
 
   def load(self, branch_id, fresh = True):
     '''


### PR DESCRIPTION
## Summary
- correct `model_RF.predict` to return proper labels
- update residual error computation in notebook to a binary indicator

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d9a29cd4483258ab18e6f41ba67ae