### PR TITLE
Add actual predicted dashboard generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # gitignore
 # ignore .pyc .csv .png files in this directory
 *.pyc
+__pycache__/
+.venv/
+venv/
+dist/
+*.egg-info/
 *.csv
 *.png
 CLAUDE.md
@@ -16,6 +21,7 @@ PARTITION_METRICS_INTEGRATION.md
 *.ipynb
 *.npz
 *.json
+!specs/**/*.json
 *.pkl
 
 test_*
@@ -25,6 +31,13 @@ deliverables/*
 
 march2026_*
 *.xlsx
+
+.DS_Store
+Thumbs.db
+*.tmp
+*.swp
+.vscode/
+.idea/
 
 summary_report.txt
 

--- a/scripts/generate_actual_predicted_dashboard.py
+++ b/scripts/generate_actual_predicted_dashboard.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""Generate a static actual-vs-predicted crisis dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import MultiPolygon, Polygon
+
+
+DEFAULT_INPUT_DIR = Path("main_ablation_results/march2026_main_backup_month_ind_cont3")
+DEFAULT_SHAPEFILE = Path(
+    r"C:\Users\swl00\IFPRI Dropbox\Weilun Shi\Google fund\Analysis\1.Source Data\Outcome\FEWSNET_IPC\FEWS NET Admin Boundaries\FEWS_Admin_LZ_v3.shp"
+)
+DEFAULT_OUTPUT_SUBDIR = "actual_predicted_dashboard"
+OUTPUT_HTML_NAME = "actual_predicted_dashboard.html"
+OUTPUT_MANIFEST_NAME = "manifest.json"
+
+INCLUDED_MODELS = {
+    "GF": "GeoRF",
+    "DT": "GeoDT",
+}
+EXCLUDED_MODEL_TOKENS = {"XGB"}
+SCOPES = ("fs1", "fs2", "fs3")
+REQUIRED_COLUMNS = ("FEWSNET_admin_code", "month_start", "y_true", "y_pred_partitioned")
+OPTIONAL_COLUMNS = ("partition_id",)
+ADMIN_CODE_ALIASES = ("FEWSNET_admin_code", "admin_code", "adm_code", "FNID")
+RESULT_DIR_RE = re.compile(r"^result_partition_k40_compare_([A-Za-z0-9]+)_fs([0-9]+)$")
+
+CLASS_COLORS = {
+    0: "#2ca02c",
+    1: "#d62728",
+    "no_data": "#e0e0e0",
+    "border": "#ffffff",
+}
+SVG_WIDTH = 1000
+SVG_HEIGHT = 650
+SIMPLIFY_TOLERANCE = 0.02
+
+
+class DashboardError(RuntimeError):
+    pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an exploratory static dashboard comparing actual and predicted crisis maps."
+    )
+    parser.add_argument("--input-dir", type=Path, default=DEFAULT_INPUT_DIR)
+    parser.add_argument("--shapefile", type=Path, default=DEFAULT_SHAPEFILE)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--simplify-tolerance", type=float, default=SIMPLIFY_TOLERANCE)
+    return parser.parse_args()
+
+
+def resolve_path(path: Path) -> Path:
+    text = str(path)
+    if os.name != "nt" and re.match(r"^[A-Za-z]:[\\/]", text):
+        drive = text[0].lower()
+        rest = text[2:].replace("\\", "/").lstrip("/")
+        return Path("/mnt") / drive / rest
+    return path
+
+
+def as_display_path(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except OSError:
+        return str(path)
+
+
+def normalize_admin_code(series: pd.Series) -> pd.Series:
+    return series.astype("string").str.strip()
+
+
+def normalize_month(series: pd.Series) -> pd.Series:
+    parsed = pd.to_datetime(series, errors="coerce")
+    if parsed.isna().any():
+        bad_count = int(parsed.isna().sum())
+        raise DashboardError(f"Found {bad_count} unparseable month_start values")
+    return parsed.dt.strftime("%Y-%m-%d")
+
+
+def discover_prediction_sources(input_dir: Path) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    if not input_dir.exists():
+        raise DashboardError(f"Input directory not found: {input_dir}")
+
+    included: list[dict[str, Any]] = []
+    excluded: list[str] = []
+    warnings: list[str] = []
+
+    for result_dir in sorted(p for p in input_dir.iterdir() if p.is_dir()):
+        match = RESULT_DIR_RE.match(result_dir.name)
+        if not match:
+            continue
+        token, scope_number = match.groups()
+        scope = f"fs{scope_number}"
+        pred_file = result_dir / "predictions_monthly.csv"
+        if token in EXCLUDED_MODEL_TOKENS:
+            excluded.append(str(pred_file if pred_file.exists() else result_dir))
+            continue
+        if token not in INCLUDED_MODELS or scope not in SCOPES:
+            warnings.append(f"Ignored unsupported result folder: {result_dir}")
+            continue
+        if not pred_file.exists():
+            warnings.append(f"Missing predictions_monthly.csv for {result_dir.name}")
+            continue
+        included.append(
+            {
+                "model": INCLUDED_MODELS[token],
+                "model_token": token,
+                "scope": scope,
+                "path": pred_file,
+            }
+        )
+
+    if not included:
+        raise DashboardError(f"No GeoRF or GeoDT prediction files found under {input_dir}")
+    return included, excluded, warnings
+
+
+def validate_binary_values(df: pd.DataFrame, column: str, source: Path) -> None:
+    values = set(pd.Series(df[column]).dropna().astype(int).unique().tolist())
+    if not values.issubset({0, 1}):
+        raise DashboardError(f"Unexpected values in {column} for {source}: {sorted(values)}")
+
+
+def load_prediction_datasets(
+    sources: list[dict[str, Any]],
+) -> tuple[dict[str, dict[str, dict[str, dict[str, int]]]], list[dict[str, Any]], list[str]]:
+    datasets: dict[str, dict[str, dict[str, dict[str, int]]]] = {}
+    included_sources: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    for source in sources:
+        path = source["path"]
+        df = pd.read_csv(path, dtype={"FEWSNET_admin_code": "string"})
+        missing = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+        if missing:
+            warnings.append(f"Omitted {path}: missing required columns {missing}")
+            continue
+
+        df = df[list(REQUIRED_COLUMNS) + [col for col in OPTIONAL_COLUMNS if col in df.columns]].copy()
+        df["FEWSNET_admin_code"] = normalize_admin_code(df["FEWSNET_admin_code"])
+        df["month_start"] = normalize_month(df["month_start"])
+        for col in ("y_true", "y_pred_partitioned"):
+            if df[col].isna().any():
+                raise DashboardError(f"Missing values in {col} for {path}")
+            validate_binary_values(df, col, path)
+            df[col] = df[col].astype(int)
+
+        duplicate_mask = df.duplicated(["FEWSNET_admin_code", "month_start"], keep="first")
+        duplicate_count = int(duplicate_mask.sum())
+        if duplicate_count:
+            warnings.append(f"{path} had {duplicate_count} duplicate polygon-month rows; kept first")
+            df = df[~duplicate_mask].copy()
+
+        key_prefix = f"{source['model']}|{source['scope']}"
+        available_dates = sorted(df["month_start"].unique().tolist())
+        for month, month_df in df.groupby("month_start", sort=True):
+            key = f"{key_prefix}|{month}"
+            datasets[key] = {
+                row["FEWSNET_admin_code"]: {
+                    "actual": int(row["y_true"]),
+                    "predicted": int(row["y_pred_partitioned"]),
+                }
+                for _, row in month_df.iterrows()
+            }
+
+        included_sources.append(
+            {
+                "model": source["model"],
+                "model_token": source["model_token"],
+                "scope": source["scope"],
+                "path": str(path),
+                "row_count": int(len(df)),
+                "available_dates": available_dates,
+                "required_columns_present": True,
+            }
+        )
+
+    if not datasets:
+        raise DashboardError("No valid prediction datasets remained after validation")
+    return datasets, included_sources, warnings
+
+
+def load_global_shapefile(shapefile_path: Path, simplify_tolerance: float) -> tuple[list[dict[str, str]], set[str], list[str]]:
+    resolved = resolve_path(shapefile_path)
+    if resolved.name != "FEWS_Admin_LZ_v3.shp":
+        raise DashboardError(f"Global FEWSNET shapefile required; got {shapefile_path}")
+    if not resolved.exists():
+        raise DashboardError(f"Shapefile not found: {resolved}")
+
+    gdf = gpd.read_file(resolved)
+    found_col = next((col for col in ADMIN_CODE_ALIASES if col in gdf.columns), None)
+    if found_col is None:
+        raise DashboardError(f"No admin code column found in shapefile. Tried {ADMIN_CODE_ALIASES}")
+    if found_col != "FEWSNET_admin_code":
+        gdf = gdf.rename(columns={found_col: "FEWSNET_admin_code"})
+
+    warnings: list[str] = []
+    invalid_count = int((~gdf.geometry.is_valid).sum())
+    if invalid_count:
+        warnings.append(f"Fixed {invalid_count} invalid shapefile geometries with buffer(0)")
+        gdf["geometry"] = gdf.geometry.buffer(0)
+
+    if gdf.crs is None:
+        warnings.append("Shapefile CRS missing; assuming EPSG:4326 for dashboard rendering")
+        gdf = gdf.set_crs(epsg=4326)
+    else:
+        gdf = gdf.to_crs(epsg=4326)
+
+    gdf["FEWSNET_admin_code"] = normalize_admin_code(gdf["FEWSNET_admin_code"])
+    gdf = gdf[gdf.geometry.notna() & ~gdf.geometry.is_empty].copy()
+    if simplify_tolerance > 0:
+        gdf["geometry"] = gdf.geometry.simplify(simplify_tolerance, preserve_topology=True)
+
+    bounds = gdf.total_bounds
+    features: list[dict[str, str]] = []
+    codes: set[str] = set()
+    for _, row in gdf.iterrows():
+        code = str(row["FEWSNET_admin_code"])
+        path = geometry_to_svg_path(row.geometry, bounds)
+        if not path:
+            continue
+        features.append({"code": code, "path": path})
+        codes.add(code)
+
+    if not features:
+        raise DashboardError("No shapefile features could be converted for dashboard rendering")
+    return features, codes, warnings
+
+
+def transform_xy(x: float, y: float, bounds: Any) -> tuple[float, float]:
+    minx, miny, maxx, maxy = bounds
+    width = max(maxx - minx, 1e-9)
+    height = max(maxy - miny, 1e-9)
+    scale = min((SVG_WIDTH - 40) / width, (SVG_HEIGHT - 40) / height)
+    drawn_w = width * scale
+    drawn_h = height * scale
+    offset_x = (SVG_WIDTH - drawn_w) / 2
+    offset_y = (SVG_HEIGHT - drawn_h) / 2
+    sx = offset_x + (x - minx) * scale
+    sy = offset_y + (maxy - y) * scale
+    return sx, sy
+
+
+def ring_to_path(coords: Any, bounds: Any) -> str:
+    parts: list[str] = []
+    for idx, (x, y) in enumerate(coords):
+        if not math.isfinite(x) or not math.isfinite(y):
+            continue
+        sx, sy = transform_xy(x, y, bounds)
+        command = "M" if idx == 0 else "L"
+        parts.append(f"{command}{sx:.2f},{sy:.2f}")
+    if parts:
+        parts.append("Z")
+    return " ".join(parts)
+
+
+def polygon_to_path(poly: Polygon, bounds: Any) -> str:
+    if poly.is_empty:
+        return ""
+    parts = [ring_to_path(poly.exterior.coords, bounds)]
+    parts.extend(ring_to_path(ring.coords, bounds) for ring in poly.interiors)
+    return " ".join(part for part in parts if part)
+
+
+def geometry_to_svg_path(geometry: Any, bounds: Any) -> str:
+    if isinstance(geometry, Polygon):
+        return polygon_to_path(geometry, bounds)
+    if isinstance(geometry, MultiPolygon):
+        return " ".join(polygon_to_path(poly, bounds) for poly in geometry.geoms)
+    return ""
+
+
+def build_availability(datasets: dict[str, dict[str, dict[str, int]]]) -> dict[str, Any]:
+    models: set[str] = set()
+    scopes_by_model: dict[str, set[str]] = {}
+    dates_by_model_scope: dict[str, set[str]] = {}
+
+    for key in datasets:
+        model, scope, month = key.split("|")
+        models.add(model)
+        scopes_by_model.setdefault(model, set()).add(scope)
+        dates_by_model_scope.setdefault(f"{model}|{scope}", set()).add(month)
+
+    return {
+        "models": sorted(models),
+        "scopesByModel": {model: sorted(scopes) for model, scopes in sorted(scopes_by_model.items())},
+        "datesByModelScope": {key: sorted(dates) for key, dates in sorted(dates_by_model_scope.items())},
+    }
+
+
+def build_smoke_test(datasets: dict[str, dict[str, dict[str, int]]], geometry_codes: set[str]) -> dict[str, Any]:
+    preferred_key = "GeoRF|fs2|2024-06-01"
+    keys = [preferred_key] if preferred_key in datasets else []
+    keys.extend(key for key in sorted(datasets) if key not in keys)
+
+    for key in keys:
+        model, scope, month = key.split("|")
+        records = datasets[key]
+        join_rows = len(set(records) & geometry_codes)
+        if join_rows > 0:
+            return {"model": model, "scope": scope, "date": month, "join_rows": join_rows, "passed": True}
+    first_key = sorted(datasets)[0]
+    model, scope, month = first_key.split("|")
+    return {"model": model, "scope": scope, "date": month, "join_rows": 0, "passed": False}
+
+
+def validate_output_dir(output_dir: Path, input_dir: Path) -> Path:
+    resolved = output_dir.resolve()
+    forbidden_names = {"deliverables", "prediction_pipeline"}
+    if any(part in forbidden_names for part in resolved.parts):
+        raise DashboardError(f"Refusing to write exploratory dashboard under protected directory: {resolved}")
+    if resolved.suffix.lower() in {".csv", ".xlsx", ".shp"}:
+        raise DashboardError(f"Output directory cannot be a source/data file path: {resolved}")
+    source_root = input_dir.resolve()
+    if not str(resolved).startswith(str(source_root)):
+        print(f"WARNING: output directory is outside input result directory: {resolved}")
+    resolved.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def make_manifest(
+    input_dir: Path,
+    shapefile_path: Path,
+    included_sources: list[dict[str, Any]],
+    excluded_sources: list[str],
+    availability: dict[str, Any],
+    output_html: Path,
+    smoke_test: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    available_scopes = sorted({scope for scopes in availability["scopesByModel"].values() for scope in scopes})
+    available_dates = sorted({date for dates in availability["datesByModelScope"].values() for date in dates})
+    return {
+        "workflow_mode": "exploratory diagnostics/tooling",
+        "production_status": "exploratory",
+        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_directory": str(input_dir),
+        "included_sources": included_sources,
+        "excluded_sources": excluded_sources,
+        "shapefile_path": str(shapefile_path),
+        "join_key": "FEWSNET_admin_code",
+        "available_models": availability["models"],
+        "available_scopes": available_scopes,
+        "available_dates": available_dates,
+        "label_contract": {
+            "actual_field": "y_true",
+            "predicted_field": "y_pred_partitioned",
+            "non_crisis_value": 0,
+            "crisis_value": 1,
+        },
+        "threshold_contract": "none; existing binary labels only",
+        "output_html": str(output_html),
+        "optional_assets": [],
+        "smoke_test": smoke_test,
+        "omissions_or_warnings": warnings,
+    }
+
+
+def json_for_script(payload: Any) -> str:
+    return json.dumps(payload, separators=(",", ":")).replace("</", "<\\/")
+
+
+def render_html(payload: dict[str, Any]) -> str:
+    data_json = json_for_script(payload)
+    return f"""<!doctype html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+<title>Actual vs Predicted Crisis Dashboard</title>
+<style>
+:root {{ --crisis: {CLASS_COLORS[1]}; --noncrisis: {CLASS_COLORS[0]}; --nodata: {CLASS_COLORS['no_data']}; --border: #ffffff; }}
+body {{ margin: 0; font-family: Arial, sans-serif; color: #222; background: #f6f7f9; }}
+header {{ padding: 16px 20px; background: #1f2937; color: white; }}
+header h1 {{ margin: 0 0 6px; font-size: 22px; }}
+header p {{ margin: 0; font-size: 13px; color: #d1d5db; }}
+.controls {{ display: grid; grid-template-columns: repeat(5, minmax(150px, 1fr)); gap: 12px; padding: 14px 20px; background: white; border-bottom: 1px solid #d7dce2; }}
+.control label {{ display: block; font-size: 12px; font-weight: bold; margin-bottom: 4px; }}
+select, input[type=range] {{ width: 100%; }}
+.status {{ min-height: 20px; padding: 0 20px 12px; background: white; color: #7f1d1d; font-weight: bold; }}
+.panels {{ display: grid; grid-template-columns: 1fr 1fr; gap: 16px; padding: 16px 20px 8px; }}
+.panel {{ background: white; border: 1px solid #d7dce2; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.08); }}
+.panel h2 {{ margin: 0; padding: 12px 14px 4px; font-size: 18px; }}
+.panel .subtitle {{ padding: 0 14px 8px; font-size: 12px; color: #4b5563; }}
+svg {{ display: block; width: 100%; height: auto; background: #eef2f7; }}
+.base path, .overlay path {{ stroke: var(--border); stroke-width: .35; vector-effect: non-scaling-stroke; }}
+.summary {{ padding: 10px 14px 14px; font-size: 13px; }}
+.legend {{ display: flex; gap: 18px; padding: 8px 20px 18px; font-size: 13px; align-items: center; }}
+.swatch {{ display: inline-block; width: 14px; height: 14px; border: 1px solid #999; vertical-align: -2px; margin-right: 5px; }}
+footer {{ padding: 0 20px 16px; font-size: 12px; color: #555; }}
+@media (max-width: 900px) {{ .controls, .panels {{ grid-template-columns: 1fr; }} }}
+</style>
+</head>
+<body>
+<header>
+  <h1>Actual vs Partitioned Predicted Food Crisis</h1>
+  <p>Exploratory diagnostics using existing GeoRF/GeoDT month-ind outputs and the global FEWSNET shapefile.</p>
+</header>
+<section class=\"controls\">
+  <div class=\"control\"><label for=\"modelSelect\">Model</label><select id=\"modelSelect\"></select></div>
+  <div class=\"control\"><label for=\"scopeSelect\">Forecasting scope</label><select id=\"scopeSelect\"></select></div>
+  <div class=\"control\"><label for=\"dateSelect\">Test month</label><select id=\"dateSelect\"></select></div>
+  <div class=\"control\"><label for=\"leftAlpha\">Left prediction alpha: <span id=\"leftAlphaValue\">0.00</span></label><input id=\"leftAlpha\" type=\"range\" min=\"0\" max=\"1\" step=\"0.05\" value=\"0\"></div>
+  <div class=\"control\"><label for=\"rightAlpha\">Right prediction alpha: <span id=\"rightAlphaValue\">1.00</span></label><input id=\"rightAlpha\" type=\"range\" min=\"0\" max=\"1\" step=\"0.05\" value=\"1\"></div>
+</section>
+<div id=\"status\" class=\"status\"></div>
+<section class=\"panels\">
+  <article class=\"panel\">
+    <h2>Actual crisis distribution</h2>
+    <div class=\"subtitle\">Base layer: actual labels (y_true). Prediction overlay defaults to alpha 0.</div>
+    <svg id=\"actualMap\" viewBox=\"0 0 {SVG_WIDTH} {SVG_HEIGHT}\" role=\"img\" aria-label=\"Actual crisis map\"></svg>
+    <div id=\"actualSummary\" class=\"summary\"></div>
+  </article>
+  <article class=\"panel\">
+    <h2>Predicted crisis distribution</h2>
+    <div class=\"subtitle\">Base layer: actual labels (y_true). Prediction overlay defaults to alpha 1.</div>
+    <svg id=\"predictedMap\" viewBox=\"0 0 {SVG_WIDTH} {SVG_HEIGHT}\" role=\"img\" aria-label=\"Predicted crisis map\"></svg>
+    <div id=\"predictedSummary\" class=\"summary\"></div>
+  </article>
+</section>
+<div class=\"legend\">
+  <span><span class=\"swatch\" style=\"background: var(--noncrisis)\"></span>Non-crisis (0)</span>
+  <span><span class=\"swatch\" style=\"background: var(--crisis)\"></span>Crisis (1)</span>
+  <span><span class=\"swatch\" style=\"background: var(--nodata)\"></span>No data</span>
+</div>
+<footer id=\"provenance\"></footer>
+<script>
+const DASHBOARD_DATA = {data_json};
+const COLORS = {{0: DASHBOARD_DATA.colors[0], 1: DASHBOARD_DATA.colors[1], no_data: DASHBOARD_DATA.colors.no_data}};
+const modelSelect = document.getElementById('modelSelect');
+const scopeSelect = document.getElementById('scopeSelect');
+const dateSelect = document.getElementById('dateSelect');
+const statusEl = document.getElementById('status');
+const leftAlpha = document.getElementById('leftAlpha');
+const rightAlpha = document.getElementById('rightAlpha');
+const leftAlphaValue = document.getElementById('leftAlphaValue');
+const rightAlphaValue = document.getElementById('rightAlphaValue');
+
+function option(value, text) {{
+  const opt = document.createElement('option');
+  opt.value = value;
+  opt.textContent = text;
+  return opt;
+}}
+
+function fillSelect(select, values) {{
+  select.textContent = '';
+  values.forEach(value => select.appendChild(option(value, value)));
+}}
+
+function setupSelectors() {{
+  fillSelect(modelSelect, DASHBOARD_DATA.availability.models);
+  updateScopes();
+}}
+
+function updateScopes() {{
+  const model = modelSelect.value;
+  fillSelect(scopeSelect, DASHBOARD_DATA.availability.scopesByModel[model] || []);
+  updateDates();
+}}
+
+function updateDates() {{
+  const key = `${{modelSelect.value}}|${{scopeSelect.value}}`;
+  fillSelect(dateSelect, DASHBOARD_DATA.availability.datesByModelScope[key] || []);
+  renderAll();
+}}
+
+function classColor(value) {{
+  return value === 0 || value === 1 ? COLORS[value] : COLORS.no_data;
+}}
+
+function buildLayer(records, field, opacity) {{
+  const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  group.setAttribute('class', field === 'actual' ? 'base' : 'overlay');
+  group.setAttribute('opacity', opacity);
+  for (const feature of DASHBOARD_DATA.features) {{
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    const rec = records ? records[feature.code] : null;
+    const value = rec ? rec[field] : null;
+    path.setAttribute('d', feature.path);
+    path.setAttribute('fill', classColor(value));
+    path.setAttribute('fill-rule', 'evenodd');
+    path.dataset.code = feature.code;
+    group.appendChild(path);
+  }}
+  return group;
+}}
+
+function renderMap(svg, records, predOpacity) {{
+  svg.textContent = '';
+  svg.appendChild(buildLayer(records, 'actual', 1));
+  svg.appendChild(buildLayer(records, 'predicted', predOpacity));
+}}
+
+function summarize(records) {{
+  if (!records) return 'No data available for this selection.';
+  const values = Object.values(records);
+  const matched = values.length;
+  const actualCrisis = values.filter(row => row.actual === 1).length;
+  const predictedCrisis = values.filter(row => row.predicted === 1).length;
+  const noData = DASHBOARD_DATA.features.length - matched;
+  return `Matched polygons: ${{matched.toLocaleString()}} | Actual crisis: ${{actualCrisis.toLocaleString()}} | Predicted crisis: ${{predictedCrisis.toLocaleString()}} | No data polygons: ${{noData.toLocaleString()}}`;
+}}
+
+function renderAll() {{
+  leftAlphaValue.textContent = Number(leftAlpha.value).toFixed(2);
+  rightAlphaValue.textContent = Number(rightAlpha.value).toFixed(2);
+  const key = `${{modelSelect.value}}|${{scopeSelect.value}}|${{dateSelect.value}}`;
+  const records = DASHBOARD_DATA.datasets[key];
+  if (!records) {{
+    statusEl.textContent = 'No data available for the selected model, scope, and date.';
+  }} else {{
+    statusEl.textContent = '';
+  }}
+  renderMap(document.getElementById('actualMap'), records, Number(leftAlpha.value));
+  renderMap(document.getElementById('predictedMap'), records, Number(rightAlpha.value));
+  const summary = summarize(records);
+  document.getElementById('actualSummary').textContent = summary;
+  document.getElementById('predictedSummary').textContent = summary;
+}}
+
+modelSelect.addEventListener('change', updateScopes);
+scopeSelect.addEventListener('change', updateDates);
+dateSelect.addEventListener('change', renderAll);
+leftAlpha.addEventListener('input', renderAll);
+rightAlpha.addEventListener('input', renderAll);
+
+document.getElementById('provenance').textContent = `Generated from ${{DASHBOARD_DATA.manifest.source_directory}} | Shapefile: ${{DASHBOARD_DATA.manifest.shapefile_path}} | Threshold: ${{DASHBOARD_DATA.manifest.threshold_contract}}`;
+setupSelectors();
+</script>
+</body>
+</html>
+"""
+
+
+def write_dashboard(output_dir: Path, payload: dict[str, Any], manifest: dict[str, Any]) -> tuple[Path, Path]:
+    html_path = output_dir / OUTPUT_HTML_NAME
+    manifest_path = output_dir / OUTPUT_MANIFEST_NAME
+    html_path.write_text(render_html(payload), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    return html_path, manifest_path
+
+
+def main() -> int:
+    args = parse_args()
+    input_dir = resolve_path(args.input_dir)
+    shapefile_path = resolve_path(args.shapefile)
+    output_dir_arg = args.output_dir if args.output_dir is not None else input_dir / DEFAULT_OUTPUT_SUBDIR
+    output_dir = validate_output_dir(resolve_path(output_dir_arg), input_dir)
+
+    print("Generating actual-vs-predicted crisis dashboard")
+    print(f"Input directory: {input_dir}")
+    print(f"Shapefile: {shapefile_path}")
+    print(f"Output directory: {output_dir}")
+
+    sources, excluded_sources, warnings = discover_prediction_sources(input_dir)
+    datasets, included_sources, dataset_warnings = load_prediction_datasets(sources)
+    warnings.extend(dataset_warnings)
+    features, geometry_codes, geometry_warnings = load_global_shapefile(shapefile_path, args.simplify_tolerance)
+    warnings.extend(geometry_warnings)
+
+    availability = build_availability(datasets)
+    smoke_test = build_smoke_test(datasets, geometry_codes)
+    if not smoke_test["passed"]:
+        raise DashboardError("Smoke-test shapefile join failed for all available selections")
+
+    html_path = output_dir / OUTPUT_HTML_NAME
+    manifest = make_manifest(
+        input_dir=input_dir,
+        shapefile_path=shapefile_path,
+        included_sources=included_sources,
+        excluded_sources=excluded_sources,
+        availability=availability,
+        output_html=html_path,
+        smoke_test=smoke_test,
+        warnings=warnings,
+    )
+    payload = {
+        "features": features,
+        "datasets": datasets,
+        "availability": availability,
+        "colors": CLASS_COLORS,
+        "manifest": manifest,
+    }
+    html_path, manifest_path = write_dashboard(output_dir, payload, manifest)
+
+    print(f"Included sources: {len(included_sources)}")
+    print(f"Excluded XGB sources: {len(excluded_sources)}")
+    print(f"Feature paths: {len(features)}")
+    print(f"Smoke test: {smoke_test}")
+    print(f"HTML: {html_path}")
+    print(f"Manifest: {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except DashboardError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/specs/002-actual-predicted-dashboard/checklists/requirements.md
+++ b/specs/002-actual-predicted-dashboard/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Actual Predicted Dashboard
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+Validation completed on 2026-05-14. The spec intentionally names project data files, fields, and shapefile paths because the user requested a data contract and the GeoRF constitution requires source, geographic scope, threshold, and artifact provenance for map-rendering features. No clarification markers remain.

--- a/specs/002-actual-predicted-dashboard/contracts/dashboard-generation-contract.md
+++ b/specs/002-actual-predicted-dashboard/contracts/dashboard-generation-contract.md
@@ -1,0 +1,71 @@
+# Contract: Dashboard Generation
+
+## Purpose
+
+Defines the expected input, output, validation, and UI behavior for generating the exploratory actual-vs-predicted crisis dashboard.
+
+## Generator Inputs
+
+| Input | Required | Contract |
+|-------|----------|----------|
+| Source result directory | Yes | Defaults to `main_ablation_results/march2026_main_backup_month_ind_cont3` unless explicitly overridden. |
+| Prediction files | Yes | Include only `result_partition_k40_compare_GF_fs{1,2,3}/predictions_monthly.csv` and `result_partition_k40_compare_DT_fs{1,2,3}/predictions_monthly.csv` when present. |
+| Excluded files | Yes | Discover and document `result_partition_k40_compare_XGB_fs*`, but never include them in dashboard model options or map data. |
+| Shapefile | Yes | Use global `FEWS_Admin_LZ_v3.shp`; reject Nigeria-only shapefile defaults for this feature. |
+| Output directory | Yes | Defaults to `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/`. |
+
+## Required Prediction Columns
+
+Each included prediction file must provide:
+
+| Column | Meaning |
+|--------|---------|
+| `FEWSNET_admin_code` | Polygon join key. |
+| `month_start` | Test month/date; normalized to `YYYY-MM-DD` and sorted chronologically. |
+| `y_true` | Actual binary crisis label. |
+| `y_pred_partitioned` | Partitioned predicted binary crisis label. |
+
+Optional provenance columns such as `partition_id` may be preserved in manifest summaries or diagnostics.
+
+## Label Contract
+
+- `0` means non-crisis.
+- `1` means class-1 crisis.
+- Existing labels/classes are plotted as-is.
+- No probability-to-label threshold may be applied silently.
+- If probability conversion becomes necessary, implementation must stop or require an explicit threshold name, numeric value, and source before continuing.
+
+## Spatial Join Contract
+
+- Canonical join key: `FEWSNET_admin_code`.
+- Shapefile aliases may be normalized only when they represent the same FEWSNET admin code.
+- The smoke-test selection must produce a non-empty join.
+- Polygons without selected prediction rows render as no data.
+
+## Dashboard UI Contract
+
+- Model selector contains exactly `GeoRF` and `GeoDT` when both are available; it never contains GeoXGB/XGBoost.
+- Scope selector contains available `fs1`, `fs2`, and `fs3` combinations only.
+- Date selector contains normalized available `month_start` dates sorted chronologically.
+- For the active selection, the left map panel shows actual crisis distribution from `y_true`.
+- For the active selection, the right map panel shows predicted crisis distribution from `y_pred_partitioned`.
+- Both panels use the same geographic canvas and clearly visible labels.
+- Missing or incomplete selections display an explicit no-data/incomplete-data message and must not retain stale maps.
+- Prediction overlay transparency defaults to actual-only on the left and predicted-visible on the right; an alpha control is included when practical.
+
+## Output Contract
+
+| Output | Required | Contract |
+|--------|----------|----------|
+| Dashboard HTML | Yes | Prefer one self-contained static HTML file. Supporting assets are allowed only if needed for size or performance. |
+| Manifest | Yes | JSON or short note documenting provenance, availability, exclusions, join key, shapefile source, value meanings, smoke-test result, and output path. |
+| Assets | Optional | If emitted, must stay in the same exploratory output directory and be listed in the manifest. |
+
+## Forbidden Operations
+
+- No model training or retraining.
+- No full multi-hour batch execution.
+- No notebook execution.
+- No changes to `ACTIVE_LAGS`.
+- No changes to partition-map semantics or spatial clustering logic.
+- No overwriting standard forecast, standalone prediction, or synthetic scenario deliverables.

--- a/specs/002-actual-predicted-dashboard/contracts/manifest.schema.json
+++ b/specs/002-actual-predicted-dashboard/contracts/manifest.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ActualPredictedDashboardManifest",
+  "type": "object",
+  "required": [
+    "workflow_mode",
+    "production_status",
+    "source_directory",
+    "included_sources",
+    "excluded_sources",
+    "shapefile_path",
+    "join_key",
+    "available_models",
+    "available_scopes",
+    "available_dates",
+    "label_contract",
+    "threshold_contract",
+    "output_html",
+    "smoke_test"
+  ],
+  "properties": {
+    "workflow_mode": {"const": "exploratory diagnostics/tooling"},
+    "production_status": {"const": "exploratory"},
+    "source_directory": {"type": "string", "minLength": 1},
+    "included_sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["model", "model_token", "scope", "path", "row_count", "available_dates"],
+        "properties": {
+          "model": {"enum": ["GeoRF", "GeoDT"]},
+          "model_token": {"enum": ["GF", "DT"]},
+          "scope": {"enum": ["fs1", "fs2", "fs3"]},
+          "path": {"type": "string", "minLength": 1},
+          "row_count": {"type": "integer", "minimum": 1},
+          "available_dates": {"type": "array", "items": {"type": "string"}}
+        },
+        "additionalProperties": true
+      }
+    },
+    "excluded_sources": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "shapefile_path": {"type": "string", "pattern": "FEWS_Admin_LZ_v3\\.shp$"},
+    "join_key": {"const": "FEWSNET_admin_code"},
+    "available_models": {
+      "type": "array",
+      "items": {"enum": ["GeoRF", "GeoDT"]},
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "available_scopes": {
+      "type": "array",
+      "items": {"enum": ["fs1", "fs2", "fs3"]},
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "available_dates": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "label_contract": {
+      "type": "object",
+      "required": ["actual_field", "predicted_field", "non_crisis_value", "crisis_value"],
+      "properties": {
+        "actual_field": {"const": "y_true"},
+        "predicted_field": {"const": "y_pred_partitioned"},
+        "non_crisis_value": {"const": 0},
+        "crisis_value": {"const": 1}
+      },
+      "additionalProperties": true
+    },
+    "threshold_contract": {"const": "none; existing binary labels only"},
+    "output_html": {"type": "string", "minLength": 1},
+    "optional_assets": {"type": "array", "items": {"type": "string"}},
+    "smoke_test": {
+      "type": "object",
+      "required": ["model", "scope", "date", "join_rows", "passed"],
+      "properties": {
+        "model": {"enum": ["GeoRF", "GeoDT"]},
+        "scope": {"enum": ["fs1", "fs2", "fs3"]},
+        "date": {"type": "string"},
+        "join_rows": {"type": "integer", "minimum": 0},
+        "passed": {"type": "boolean"}
+      },
+      "additionalProperties": true
+    },
+    "omissions_or_warnings": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": true
+}

--- a/specs/002-actual-predicted-dashboard/data-model.md
+++ b/specs/002-actual-predicted-dashboard/data-model.md
@@ -1,0 +1,113 @@
+# Data Model: Actual Predicted Dashboard
+
+## Entity: Dashboard Selection
+
+**Purpose**: Identifies one view state in the dashboard.
+
+**Fields**:
+- `model`: Display model family, one of `GeoRF` or `GeoDT`.
+- `model_token`: Source folder token, one of `GF` or `DT`.
+- `scope`: Forecasting scope, one of `fs1`, `fs2`, or `fs3`.
+- `month_start`: Test month in normalized `YYYY-MM-DD` form.
+
+**Validation Rules**:
+- The combination must exist in the discovered availability index.
+- `model_token = XGB` is never valid for dashboard selection.
+- Dates sort chronologically, not lexicographically by display label.
+
+**Relationships**:
+- Selects one Prediction Dataset.
+- Controls the actual and predicted layer values displayed for each Global FEWSNET Polygon.
+
+## Entity: Prediction Dataset
+
+**Purpose**: Represents one included `predictions_monthly.csv` source file for a model/scope.
+
+**Fields**:
+- `source_path`: Path to the source CSV.
+- `model`: `GeoRF` or `GeoDT`.
+- `model_token`: `GF` or `DT`.
+- `scope`: `fs1`, `fs2`, or `fs3`.
+- `available_months`: Sorted list of normalized `month_start` values.
+- `row_count`: Number of rows read from the file.
+- `required_columns_present`: Boolean result for `FEWSNET_admin_code`, `month_start`, `y_true`, and `y_pred_partitioned`.
+- `excluded`: Always false for this entity; XGB discoveries are represented in the manifest, not as datasets.
+
+**Validation Rules**:
+- Required columns must be present before a dataset is included.
+- `y_true` values must be binary 0/1 for included rows.
+- `y_pred_partitioned` values must be binary 0/1 for included rows.
+- `month_start` must be parseable and normalizable to dates.
+- Rows must not be modified in the source CSV.
+
+**Relationships**:
+- Provides Prediction Records.
+- Is summarized in Dashboard Manifest.
+
+## Entity: Prediction Record
+
+**Purpose**: Represents one polygon-month actual/predicted label record.
+
+**Fields**:
+- `FEWSNET_admin_code`: Spatial join key.
+- `month_start`: Normalized test month.
+- `y_true`: Actual binary crisis label, where `1` is crisis and `0` is non-crisis.
+- `y_pred_partitioned`: Partitioned predicted binary crisis label, where `1` is crisis and `0` is non-crisis.
+- `partition_id`: Existing source partition identifier, retained for provenance when present.
+
+**Validation Rules**:
+- `FEWSNET_admin_code` and `month_start` must be present for map display.
+- `y_true` and `y_pred_partitioned` must not be silently coerced from probabilities or IPC phases.
+- Records with missing actual or predicted labels for a selected combination trigger visible incomplete-data handling.
+
+**Relationships**:
+- Joins to one Global FEWSNET Polygon by `FEWSNET_admin_code`.
+- Supplies actual and predicted panel coloring for one Dashboard Selection.
+
+## Entity: Global FEWSNET Polygon
+
+**Purpose**: Represents one map polygon from the global FEWSNET shapefile.
+
+**Fields**:
+- `FEWSNET_admin_code`: Canonical spatial key after alias normalization.
+- `geometry`: Polygon or multipolygon geometry from `FEWS_Admin_LZ_v3.shp`.
+- `display_path`: Browser-ready rendered path or equivalent geometry representation.
+- `metadata`: Optional shapefile attributes retained only when useful for display or debugging.
+
+**Validation Rules**:
+- Shapefile source must be the global FEWSNET shapefile, not `Nigeria.shp`.
+- Alias normalization is allowed only when it resolves to `FEWSNET_admin_code`.
+- Invalid geometries must be repaired or reported before rendering.
+- A selected model-scope-month must have at least one non-empty join to polygons for a valid smoke test.
+
+**Relationships**:
+- May have zero or one Prediction Record for a Dashboard Selection.
+- Polygons without matching records render as no data.
+
+## Entity: Dashboard Manifest
+
+**Purpose**: Captures provenance and validation details for the generated dashboard.
+
+**Fields**:
+- `workflow_mode`: `exploratory diagnostics/tooling`.
+- `production_status`: `exploratory`.
+- `source_directory`: Source result directory.
+- `included_sources`: List of included Prediction Datasets.
+- `excluded_sources`: List or patterns for excluded XGB folders.
+- `shapefile_path`: Global FEWSNET shapefile path used.
+- `join_key`: `FEWSNET_admin_code`.
+- `available_models`: `GeoRF`, `GeoDT`.
+- `available_scopes`: Available subset of `fs1`, `fs2`, `fs3`.
+- `available_dates`: Sorted normalized test months.
+- `label_contract`: Actual and predicted binary label meanings.
+- `threshold_contract`: `none; existing binary labels only`.
+- `output_html`: Dashboard path.
+- `optional_assets`: Supporting assets if generated.
+- `smoke_test`: Selected model/scope/date and join result.
+- `omissions_or_warnings`: Missing folders, unmatched rows, unexpected values, or other validation notes.
+
+**Validation Rules**:
+- Manifest must identify 100% of included source files.
+- Manifest must explicitly document XGB exclusion when XGB source folders exist.
+- Manifest must record the output path and shapefile source.
+- Manifest must not claim production forecast status.

--- a/specs/002-actual-predicted-dashboard/plan.md
+++ b/specs/002-actual-predicted-dashboard/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Actual Predicted Dashboard
+
+**Branch**: `002-actual-predicted-dashboard` | **Date**: 2026-05-14 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-actual-predicted-dashboard/spec.md`
+
+**Note**: This template is filled in by the Spec Kit Plan command or skill. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Generate an exploratory static HTML dashboard that compares actual versus partitioned predicted crisis distributions for existing GeoRF and GeoDT month-ind evaluation outputs. The implementation will add a lightweight generator under the existing `scripts/` tooling area, reuse the current CSV/shapefile data contract, embed compact browser-ready map/data payloads into one self-contained HTML file by default, and write a manifest beside the dashboard without rerunning training or standard batch workflows.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+ for generation; static HTML/CSS/browser JavaScript for local viewing
+**Primary Dependencies**: Existing project geospatial/data stack: pandas, GeoPandas, Shapely, NumPy; standard-library JSON/path handling; no server framework or Leaflet-style GIS frontend
+**Storage**: Local filesystem inputs and generated artifacts only; source CSVs and shapefile are read-only
+**Testing**: Generator smoke/dry-run validation, data-contract checks, manifest inspection, and manual browser validation of selector/panel behavior
+**Target Platform**: Local project workspace, generated from WSL or Windows with the project geospatial environment and opened in a desktop browser
+**Project Type**: Existing repository diagnostic/tooling script plus generated static dashboard artifact
+**Performance Goals**: Dashboard opens and selectors populate in under 30 seconds for included GeoRF/GeoDT fs1-fs3 month-ind data on a typical workstation
+**Constraints**: No model retraining, no full batch execution, no notebook execution, no `ACTIVE_LAGS` changes, no partition-map or clustering changes, no standard forecast/scenario deliverable overwrites, self-contained HTML preferred with supporting assets only if needed for size/performance
+**Scale/Scope**: Six included prediction files (GeoRF/GeoDT x fs1/fs2/fs3), each inspected at 62,189 polygon-month rows across 12 test months; XGB folders are discovered only to document exclusion; global FEWSNET shapefile is the spatial source
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Initial Gate
+
+- **Pipeline Contract**: PASS. Affected workflow is exploratory diagnostics/tooling. Canonical entry point will be a generator script under `scripts/`; required inputs are existing `predictions_monthly.csv` files and the global FEWSNET shapefile; expected outputs are one dashboard and one manifest in an exploratory output directory.
+- **Temporal Integrity**: PASS. The feature reads `month_start` from existing labeled outputs, includes fs1/fs2/fs3 as folder suffixes, does not recompute feature-month to target-month mappings, and leaves `ACTIVE_LAGS` unchanged.
+- **Spatial Partitioning**: PASS. The feature consumes post-evaluation `y_pred_partitioned` labels only and does not read, generate, modify, or reinterpret partition maps. `k40` remains inherited from source folder names and is not described as 40 clusters.
+- **Threshold & Prediction Contract**: PASS. No prediction threshold is introduced because the dashboard plots existing binary `y_true` and `y_pred_partitioned` labels. Probability-to-label conversion remains out of scope unless explicitly replanned.
+- **Geographic Scope**: PASS. Map joining/rendering must use the global FEWSNET shapefile `FEWS_Admin_LZ_v3.shp`; Nigeria-only defaults are explicitly rejected.
+- **Crisis-Class Validation**: PASS. Class 1 is the repository positive crisis label from existing `y_true`/`y_pred_partitioned` values. This is a labeled diagnostic, so smoke validation focuses on non-empty joins and actual-vs-predicted display rather than rerunning model metrics.
+- **Operational Hygiene**: PASS. Outputs remain in an exploratory result subdirectory, source CSVs are read-only, no notebook execution is required, and any Windows-facing launcher/status text must remain ASCII-safe if added later.
+
+### Post-Design Gate
+
+- **Pipeline Contract**: PASS. Research, data model, contracts, and quickstart define the generator inputs, dashboard/manifest outputs, and validation path.
+- **Temporal Integrity**: PASS. Design uses only discovered `month_start` values and does not alter forecasting scope behavior.
+- **Spatial Partitioning**: PASS. Design preserves source partitioned predictions as data fields and makes no partition-map changes.
+- **Threshold & Prediction Contract**: PASS. Contracts require binary labels and reject silent thresholding.
+- **Geographic Scope**: PASS. Contracts and quickstart require global FEWSNET shapefile provenance.
+- **Crisis-Class Validation**: PASS. Data-model validation requires binary 0/1 values and smoke-test comparison for one model-scope-month.
+- **Operational Hygiene**: PASS. Quickstart avoids full batch/training/notebooks and writes to `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/`.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-actual-predicted-dashboard/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── dashboard-generation-contract.md
+│   └── manifest.schema.json
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+scripts/
+├── plot_predictions_2024.py                 # Existing reference plotting/data-join logic
+└── generate_actual_predicted_dashboard.py    # Planned dashboard generator
+
+main_ablation_results/march2026_main_backup_month_ind_cont3/
+├── result_partition_k40_compare_GF_fs1/predictions_monthly.csv
+├── result_partition_k40_compare_GF_fs2/predictions_monthly.csv
+├── result_partition_k40_compare_GF_fs3/predictions_monthly.csv
+├── result_partition_k40_compare_DT_fs1/predictions_monthly.csv
+├── result_partition_k40_compare_DT_fs2/predictions_monthly.csv
+├── result_partition_k40_compare_DT_fs3/predictions_monthly.csv
+├── result_partition_k40_compare_XGB_fs*/     # Input discovery documents exclusion only
+└── actual_predicted_dashboard/               # Planned exploratory output directory
+    ├── actual_predicted_dashboard.html
+    ├── manifest.json
+    └── assets/                               # Optional only if HTML size/performance requires it
+```
+
+**Structure Decision**: Keep implementation as one existing-repository diagnostic script under `scripts/` and generated artifacts under the source result directory’s exploratory output subfolder. Do not add a backend server, notebook, new batch launcher, or independent application structure.
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions are required.

--- a/specs/002-actual-predicted-dashboard/quickstart.md
+++ b/specs/002-actual-predicted-dashboard/quickstart.md
@@ -1,0 +1,80 @@
+# Quickstart: Actual Predicted Dashboard
+
+## Purpose
+
+Generate and smoke-test one exploratory static dashboard comparing actual crisis labels with partitioned predicted crisis labels for GeoRF and GeoDT fs1-fs3 outputs.
+
+## Preconditions
+
+- Run from the repository root.
+- Use the existing project Python/geospatial environment with pandas and GeoPandas available.
+- Do not run model training, full batch workflows, or notebooks for this feature.
+- Confirm the source result directory exists:
+  `main_ablation_results/march2026_main_backup_month_ind_cont3`
+- Confirm the global FEWSNET shapefile is available:
+  `C:\Users\swl00\IFPRI Dropbox\Weilun Shi\Google fund\Analysis\1.Source Data\Outcome\FEWSNET_IPC\FEWS NET Admin Boundaries\FEWS_Admin_LZ_v3.shp`
+
+## Planned Generator Command
+
+```bash
+python scripts/generate_actual_predicted_dashboard.py \
+  --input-dir "main_ablation_results/march2026_main_backup_month_ind_cont3" \
+  --shapefile "C:\Users\swl00\IFPRI Dropbox\Weilun Shi\Google fund\Analysis\1.Source Data\Outcome\FEWSNET_IPC\FEWS NET Admin Boundaries\FEWS_Admin_LZ_v3.shp" \
+  --output-dir "main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard"
+```
+
+If the active shell exposes Python as `python3`, use `python3` instead of `python`. If WSL `python3` does not have GeoPandas, use the documented Windows Python fallback from this workstation:
+
+```bash
+"/mnt/c/Users/swl00/AppData/Local/Microsoft/WindowsApps/python3.12.exe" scripts/generate_actual_predicted_dashboard.py \
+  --input-dir "main_ablation_results/march2026_main_backup_month_ind_cont3" \
+  --shapefile "C:\Users\swl00\IFPRI Dropbox\Weilun Shi\Google fund\Analysis\1.Source Data\Outcome\FEWSNET_IPC\FEWS NET Admin Boundaries\FEWS_Admin_LZ_v3.shp" \
+  --output-dir "main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard"
+```
+
+If running from Windows CMD, keep output ASCII-safe.
+
+## Expected Outputs
+
+```text
+main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/
+├── actual_predicted_dashboard.html
+├── manifest.json
+└── assets/                  # Only if needed for size/performance
+```
+
+The HTML should be self-contained unless asset extraction is needed for size or performance. Any supporting assets must remain in the same output directory and be listed in `manifest.json`.
+
+## Smoke-Test Path
+
+1. Generate the dashboard using the command above.
+2. Confirm `manifest.json` reports:
+   - `workflow_mode = exploratory diagnostics/tooling`
+   - `production_status = exploratory`
+   - included model tokens are only `GF` and `DT`
+   - excluded source patterns include `result_partition_k40_compare_XGB_fs*`
+   - `join_key = FEWSNET_admin_code`
+   - shapefile path ends in `FEWS_Admin_LZ_v3.shp`
+   - threshold contract is `none; existing binary labels only`
+3. Open `actual_predicted_dashboard.html` in a desktop browser.
+4. Select a known complete combination such as GeoRF, fs2, `2024-06-01`.
+5. Verify the left panel is labeled as actual/reference and uses `y_true` values.
+6. Verify the right panel is labeled as predicted/comparison and uses `y_pred_partitioned` values.
+7. Verify model choices exclude GeoXGB/XGBoost.
+8. Verify date and scope selectors populate from available data.
+9. Verify at least one selected combination has a non-empty shapefile join in the manifest smoke-test section.
+10. Verify no standard forecast, standalone prediction, or synthetic scenario deliverable was overwritten.
+
+## Failure Handling Checks
+
+- Temporarily point to an output-only copy with one model-scope file omitted to verify the missing combination is omitted or reported visibly.
+- Verify an invalid or Nigeria-only shapefile path fails validation rather than silently rendering the wrong geography.
+- Verify unexpected non-binary `y_true` or `y_pred_partitioned` values are reported and not silently reinterpreted.
+
+## Non-Goals
+
+- Do not change `ACTIVE_LAGS`.
+- Do not change partition maps, spatial clustering, or model code.
+- Do not execute notebooks.
+- Do not create a backend server, Dash app, or full GIS frontend.
+- Do not promote the output as a production forecast deliverable.

--- a/specs/002-actual-predicted-dashboard/research.md
+++ b/specs/002-actual-predicted-dashboard/research.md
@@ -1,0 +1,59 @@
+# Research: Actual Predicted Dashboard
+
+## Decision: Use existing `predictions_monthly.csv` files as the dashboard data source
+
+**Rationale**: The inspected March 2026 month-ind result directory contains the exact actual and partitioned predicted labels required by the spec. Included folders are `result_partition_k40_compare_GF_fs1`, `GF_fs2`, `GF_fs3`, `DT_fs1`, `DT_fs2`, and `DT_fs3`, each with 62,189 rows across 12 test months and columns `FEWSNET_admin_code`, `month_start`, `partition_id`, `y_true`, `y_pred_pooled`, and `y_pred_partitioned`.
+
+**Alternatives considered**:
+- Recompute predictions from trained models: rejected because the feature is exploratory diagnostics and must not run training or batch workflows.
+- Use `metrics_monthly.csv`: rejected as the primary map source because metrics are aggregate records and do not contain per-polygon labels.
+- Use `y_pred_pooled`: rejected because the feature asks for predicted crisis spatial distribution from partitioned model outputs and the reference script uses `y_pred_partitioned`.
+
+## Decision: Include GeoRF and GeoDT by folder token, exclude XGB by folder token
+
+**Rationale**: Existing source folders identify GeoRF with `GF`, GeoDT with `DT`, and GeoXGB/XGBoost with `XGB`. Including only `GF` and `DT` directly satisfies the selector contract and prevents accidental use of XGBoost data present in the same source directory.
+
+**Alternatives considered**:
+- Infer model labels from run manifests only: rejected because folder tokens are sufficient, stable for these outputs, and simpler for availability discovery.
+- Include XGB as hidden data for future toggles: rejected because the spec explicitly excludes GeoXGB/XGBoost entirely.
+
+## Decision: Use `month_start` as the canonical test-month key
+
+**Rationale**: Every inspected prediction file includes `month_start`, and the existing reference plotting script normalizes this field as a date string before filtering and rendering. The available inspected dates are February, June, and October for years 2021 through 2024.
+
+**Alternatives considered**:
+- Infer dates from file names: rejected because the files are scope-level aggregate CSVs rather than per-month files.
+- Use metrics dates: rejected because the dashboard maps prediction records, and the map rows already carry `month_start`.
+
+## Decision: Join to the global FEWSNET shapefile through `FEWSNET_admin_code`
+
+**Rationale**: The reference plotting script joins shapefile geometries to predictions using `FEWSNET_admin_code` and supports aliases that are normalized to that name. The user explicitly requires the global FEWSNET shapefile and rejects Nigeria-specific development defaults.
+
+**Alternatives considered**:
+- Use `Nigeria.shp`: rejected by the feature requirements and constitution geographic-scope rule.
+- Use centroid or country-level joins: rejected because the data already has polygon-level FEWSNET admin codes.
+
+## Decision: Plot existing binary labels without thresholding
+
+**Rationale**: Inspected `y_true` and `y_pred_partitioned` values are binary `0` and `1` in all included and excluded prediction files. The dashboard can therefore plot existing labels/classes and does not need a probability-to-binary conversion threshold.
+
+**Alternatives considered**:
+- Apply `PREDICTION_THRESHOLD = 0.5`: rejected because no probabilities are needed for this feature and adding a threshold would create unnecessary ambiguity.
+- Plot probabilities or IPC phases: rejected because the source fields and user goal are binary actual/predicted crisis distributions.
+
+## Decision: Generate static browser controls from compact embedded data
+
+**Rationale**: The dashboard needs interactive selection without a backend server or full GIS frontend. A generator can convert the shapefile and prediction rows into compact browser-ready data, embed it in a self-contained HTML file by default, and use simple controls to color the same polygon canvas for actual and predicted panels.
+
+**Alternatives considered**:
+- Pre-render one image per selection: simpler but less flexible for alpha controls and can make a self-contained HTML unnecessarily large.
+- Build a Dash app or server: rejected because the feature asks for static HTML and no backend.
+- Use Leaflet-style dynamic maps: rejected unless it proves clearly simpler, which is not necessary for this fixed diagnostic.
+
+## Decision: Write dashboard output under the source result directory in an exploratory subfolder
+
+**Rationale**: `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/` keeps the dashboard close to its source data while avoiding standard forecast, standalone prediction, and scenario deliverables.
+
+**Alternatives considered**:
+- Write under `deliverables/`: rejected because the dashboard is exploratory unless explicitly promoted.
+- Write at repository root: rejected because it separates generated artifacts from provenance and increases clutter.

--- a/specs/002-actual-predicted-dashboard/spec.md
+++ b/specs/002-actual-predicted-dashboard/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Actual Predicted Dashboard
+
+**Feature Branch**: `002-actual-predicted-dashboard`
+**Created**: 2026-05-14
+**Status**: Draft
+**Input**: User description: "Create a new Spec Kit feature for a static HTML dashboard that compares actual crisis spatial distribution against predicted crisis spatial distribution for GeoRF and GeoDT across fs1, fs2, and fs3, using existing March 2026 month-ind results and the global FEWSNET shapefile."
+
+## Clarifications
+
+### Session 2026-05-14
+
+- Q: Should the dashboard be self-contained or may it use supporting assets? → A: Self-contained HTML preferred; use assets only if needed for size/performance.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Compare actual and predicted crisis maps (Priority: P1)
+
+A food-crisis model analyst opens one generated dashboard, selects a test month, model family, and forecasting scope, and compares the actual crisis spatial distribution with the partitioned predicted crisis distribution in two side-by-side panels.
+
+**Why this priority**: This is the primary diagnostic value: a fast visual comparison of where the model agrees or disagrees with observed crisis labels without rerunning model training or batch evaluation.
+
+**Independent Test**: Can be fully tested by opening the generated dashboard, selecting one known model-scope-month combination with complete data, and confirming that the left panel shows actual crisis labels while the right panel shows predicted crisis labels for the same geography.
+
+**Acceptance Scenarios**:
+
+1. **Given** the dashboard has loaded available GeoRF and GeoDT result data, **When** the user selects GeoRF, fs2, and 2024-06-01, **Then** the left panel displays actual crisis distribution and the right panel displays predicted crisis distribution for that exact selection.
+2. **Given** a selected month, model, and scope have matched prediction and actual rows, **When** the dashboard renders both panels, **Then** both panels use the same geographic canvas and are clearly labeled as actual reference and predicted comparison.
+3. **Given** the source directory also contains GeoXGB/XGBoost results, **When** the user opens the model selector, **Then** only GeoRF and GeoDT choices are available.
+
+---
+
+### User Story 2 - Inspect available dates, scopes, and models safely (Priority: P2)
+
+A model analyst uses dashboard controls to switch among available dates, GeoRF/GeoDT models, and fs1/fs2/fs3 scopes and sees a visible message if a requested combination is unavailable rather than seeing stale or misleading maps.
+
+**Why this priority**: The result directory may contain partial or uneven artifacts over time, so the diagnostic must make availability explicit and avoid silently mixing data across months, models, or scopes.
+
+**Independent Test**: Can be tested by checking selector contents against the source result folders and by selecting or simulating a missing combination to verify that the dashboard reports the omission visibly.
+
+**Acceptance Scenarios**:
+
+1. **Given** source files exist for GeoRF and GeoDT fs1, fs2, and fs3, **When** the dashboard loads, **Then** the selectors list only available model-scope-date combinations derived from those files.
+2. **Given** one model-scope-date combination is missing or has no matched polygons, **When** that combination would otherwise be selected, **Then** the dashboard shows a clear no-data message and does not display stale maps from a previous selection.
+
+---
+
+### User Story 3 - Preserve provenance and output boundaries (Priority: P3)
+
+A project maintainer reviews the generated artifacts and can identify the source result files, selected global shapefile, join key, available models/scopes/dates, value meaning, and output location without confusing this exploratory dashboard with standard forecast deliverables.
+
+**Why this priority**: The GeoRF constitution requires workflow classification, artifact hygiene, geographic scope, and threshold provenance so exploratory diagnostics are not mistaken for production forecasts.
+
+**Independent Test**: Can be tested by reading the generated note or manifest and verifying it names the source directory, included/excluded model families, shapefile, join key, label fields, and output path.
+
+**Acceptance Scenarios**:
+
+1. **Given** the dashboard and manifest are generated, **When** a maintainer reviews the manifest, **Then** it documents the workflow as exploratory diagnostics/tooling and not a model-training, standard 3-stage evaluation, fs0-only, standalone prediction, or synthetic scenario feature.
+2. **Given** the dashboard is generated from existing predicted labels, **When** a maintainer reviews the manifest, **Then** it states that no new probability-to-label threshold was introduced.
+
+### Edge Cases
+
+- If a model-scope folder is absent, empty, or lacks `predictions_monthly.csv`, that combination is omitted from selectors and documented in the manifest.
+- If a selected date has actual labels but no predicted labels, or predicted labels but no actual labels, the dashboard shows a visible incomplete-data message for that selection.
+- If prediction rows do not join to any global FEWSNET polygons through `FEWSNET_admin_code`, generation fails or records a validation failure rather than producing an empty dashboard as if it were valid.
+- If some polygons are present in the shapefile but absent from the selected prediction rows, those polygons are visually treated as no data and counted in the manifest or dashboard summary.
+- If source values outside the expected binary classes 0 and 1 appear in `y_true` or `y_pred_partitioned`, generation records the unexpected values and does not silently reinterpret them as crisis labels.
+- If the source directory contains GeoXGB/XGBoost result folders, they are ignored for dashboard data and explicitly listed as excluded in the manifest.
+- If a Nigeria-specific shapefile path is present in older plotting defaults, it is not accepted as the geographic source for this feature.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The feature MUST generate one static dashboard artifact that supports selecting test month/date, model family, and forecasting scope from available data, with self-contained HTML preferred and supporting assets used only when needed for size or performance.
+- **FR-002**: The model selector MUST include GeoRF and GeoDT only, identified from `result_partition_k40_compare_GF_fs*` and `result_partition_k40_compare_DT_fs*` folders respectively.
+- **FR-003**: The feature MUST exclude GeoXGB/XGBoost entirely, including all `result_partition_k40_compare_XGB_fs*` source folders and any XGBoost option in the dashboard controls.
+- **FR-004**: The scope selector MUST include fs1, fs2, and fs3 where available, identified from result folder suffixes `_fs1`, `_fs2`, and `_fs3`.
+- **FR-005**: The date selector MUST use the `month_start` field from included prediction files, normalize dates consistently, and sort test months chronologically.
+- **FR-006**: For each selected date, model, and scope, the dashboard MUST show two synchronized side-by-side map panels over the same geographic canvas.
+- **FR-007**: The left panel MUST present actual crisis spatial distribution as the comparison reference, using the `y_true` field.
+- **FR-008**: The right panel MUST present partitioned predicted crisis spatial distribution, using the `y_pred_partitioned` field.
+- **FR-009**: The dashboard MUST make panel meanings visually explicit, including labels that distinguish actual/reference from predicted/comparison.
+- **FR-010**: The dashboard SHOULD support prediction overlay transparency, with actual-only viewing equivalent to prediction alpha 0 on the left panel and predicted viewing equivalent to prediction alpha 1 on the right panel.
+- **FR-011**: The feature MUST use the global FEWSNET shapefile path `C:\Users\swl00\IFPRI Dropbox\Weilun Shi\Google fund\Analysis\1.Source Data\Outcome\FEWSNET_IPC\FEWS NET Admin Boundaries\FEWS_Admin_LZ_v3.shp` for the spatial join and rendered geography.
+- **FR-012**: The feature MUST NOT use Nigeria-specific development shapefile defaults for this dashboard.
+- **FR-013**: The feature MUST join prediction and actual rows to the global shapefile through `FEWSNET_admin_code`, accepting the same known shapefile aliases used by existing plotting logic only when they resolve to `FEWSNET_admin_code`.
+- **FR-014**: The feature MUST use existing prediction labels/classes from source files and MUST NOT introduce a new prediction threshold unless probability-to-label conversion becomes unavoidable and is explicitly documented before implementation.
+- **FR-015**: The feature MUST document that inspected source values are binary labels, with `0` representing non-crisis and `1` representing crisis, for both `y_true` and `y_pred_partitioned` in the March 2026 result files.
+- **FR-016**: Missing dates, scopes, models, unmatched joins, or empty selections MUST be handled gracefully with a visible dashboard message or documented omission.
+- **FR-017**: The feature MUST generate a short note or manifest documenting source files, selected shapefile, join key, included and excluded model families, available dates, available scopes, value meanings, and output path.
+- **FR-018**: Generated artifacts MUST be saved in an appropriate exploratory output location without overwriting standard forecast deliverables, prediction deliverables, synthetic scenario deliverables, or the existing source result CSVs.
+- **FR-019**: The feature MUST be generated without model retraining, full multi-hour batch execution, notebook execution, changes to `ACTIVE_LAGS`, changes to partition-map semantics, or changes to spatial clustering logic.
+- **FR-020**: The feature MUST include a smoke-test or dry-run validation path using at least one date, one scope, and one model with both actual and predicted data.
+
+### Key Entities *(include if feature involves data)*
+
+- **Dashboard Selection**: A user-selected combination of test month/date, model family, and forecasting scope. It determines which rows are shown in both map panels.
+- **Model Family**: The included model type represented by result folders. GeoRF maps to `GF`; GeoDT maps to `DT`; GeoXGB/XGBoost maps to `XGB` and is excluded.
+- **Forecasting Scope**: The horizon identifier fs1, fs2, or fs3 available in result folder suffixes. This feature reads existing evaluated outputs and does not alter scope semantics.
+- **Prediction Record**: A row from an included `predictions_monthly.csv` containing `FEWSNET_admin_code`, `month_start`, `y_true`, and `y_pred_partitioned` for one polygon-month.
+- **Global FEWSNET Polygon**: A spatial unit from `FEWS_Admin_LZ_v3.shp` joined to prediction records through `FEWSNET_admin_code` and rendered in the dashboard.
+- **Dashboard Manifest**: A short provenance artifact that records source assumptions, availability, exclusions, join behavior, and output paths.
+
+### Pipeline & Data Assumptions *(mandatory for model/pipeline changes)*
+
+- **Workflow**: Exploratory diagnostics/tooling. This is not model training, not the standard 3-stage evaluation workflow, not fs0-only, not standalone 2026-2027 prediction, and not a synthetic scenario overlay. Outputs are exploratory unless explicitly promoted later as reviewed deliverables.
+- **Temporal Scope**: The dashboard uses already-evaluated labeled test months from `month_start` in the March 2026 result files. Inspected available months are February, June, and October for each year 2021 through 2024. Forecasting scopes are fs1, fs2, and fs3 as represented by existing result folders; no feature-month to target-month mapping is recomputed by this feature.
+- **Crisis Label**: Actual crisis is read from `y_true`; predicted crisis is read from `y_pred_partitioned`. Inspected values are binary `0` and `1`; `1` is the class-1 crisis label and `0` is non-crisis. The dashboard does not reinterpret IPC phases or probabilities.
+- **Spatial Inputs**: Source prediction/result files are `predictions_monthly.csv` under `main_ablation_results/march2026_main_backup_month_ind_cont3/result_partition_k40_compare_GF_fs1`, `...GF_fs2`, `...GF_fs3`, `...DT_fs1`, `...DT_fs2`, and `...DT_fs3`. Each inspected file contains 62,189 rows and columns `FEWSNET_admin_code`, `month_start`, `partition_id`, `y_true`, `y_pred_pooled`, and `y_pred_partitioned`. GeoXGB/XGBoost folders with `XGB` are present but excluded. Existing partition identities are inherited from these source outputs and not modified.
+- **Geographic Scope**: The dashboard uses the global FEWSNET shapefile `C:\Users\swl00\IFPRI Dropbox\Weilun Shi\Google fund\Analysis\1.Source Data\Outcome\FEWSNET_IPC\FEWS NET Admin Boundaries\FEWS_Admin_LZ_v3.shp`. Nigeria-only shapefiles are out of scope for this feature.
+- **Threshold Contract**: No new threshold is used because the dashboard plots existing binary labels/classes from `y_true` and `y_pred_partitioned`. If a later plan discovers only probabilities are available for a required case, that plan must name the threshold, numeric value, and source before conversion.
+- **Prediction Partition Maps**: The feature consumes post-evaluation `predictions_monthly.csv` outputs that already encode partitioned predictions. It does not read, generate, or change partition maps.
+- **Artifacts**: Expected artifacts are one generated static dashboard, preferably as self-contained HTML, optional supporting static assets only if needed for size or performance, and one short manifest or note. Outputs should live under an exploratory diagnostics/output location such as `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/` unless planning identifies a safer equivalent location. Standard forecast deliverables must not be overwritten.
+- **Environment**: This is an existing-repository tooling feature. Generation may be run from WSL or Windows with the project’s existing Python/geospatial environment, but it must not require notebook execution, full batch workflows, new launcher proliferation, or non-ASCII Windows CMD-facing output.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Opening the generated dashboard allows a user to select among all included GeoRF and GeoDT model-scope-date combinations found in the source directory in under 30 seconds on a typical workstation.
+- **SC-002**: The model selector contains exactly two model choices, GeoRF and GeoDT, and contains zero GeoXGB/XGBoost choices.
+- **SC-003**: For a smoke-tested combination with complete data, the dashboard renders two side-by-side panels where the left panel uses actual labels and the right panel uses predicted labels for the same date, model, scope, and geographic extent.
+- **SC-004**: The generated manifest identifies 100% of included prediction source files, the excluded XGBoost source pattern, the global shapefile path, the join key, available scopes, available dates, and output artifact path.
+- **SC-005**: A dry-run or smoke-test validates at least one GeoRF or GeoDT fs1/fs2/fs3 month with a successful non-empty shapefile join and no model training, full batch execution, or notebook execution.
+- **SC-006**: Missing or unavailable model-scope-date combinations produce a visible no-data message or documented omission instead of stale maps or silent failure.
+- **SC-007**: The output process overwrites zero standard forecast deliverables, zero standalone prediction deliverables, and zero synthetic scenario deliverables.
+
+## Assumptions
+
+- Users are analysts or maintainers who can open a local static dashboard artifact from the project workspace.
+- The existing March 2026 month-ind result directory remains the authoritative source for this dashboard unless a later command explicitly changes the source directory.
+- The global FEWSNET shapefile is available at the documented project workstation path or an equivalent path resolved during implementation and recorded in the manifest.
+- Existing `predictions_monthly.csv` files contain the complete data needed for actual-vs-predicted comparison; `metrics_monthly.csv`, `metrics_polygon_overall.csv`, and `run_manifest.json` may support provenance but are not the primary map data source.
+- The feature is exploratory diagnostics/tooling and should not be promoted as a production forecast or reviewed deliverable without a separate explicit decision.
+- The alpha-control behavior is preferred when practical, but the core requirement is that the dashboard clearly provides actual-only reference and predicted comparison views side by side.

--- a/specs/002-actual-predicted-dashboard/tasks.md
+++ b/specs/002-actual-predicted-dashboard/tasks.md
@@ -1,0 +1,191 @@
+# Tasks: Actual Predicted Dashboard
+
+**Input**: Design documents from `/specs/002-actual-predicted-dashboard/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: The feature specification requests a smoke-test/dry-run validation path, not a formal TDD suite. Tasks therefore include validation and manual browser smoke checks rather than separate automated test-first tasks.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the generator script location and establish constants that reflect the plan contract.
+
+- [X] T001 Create `scripts/generate_actual_predicted_dashboard.py` with argparse entry point accepting `--input-dir`, `--shapefile`, and `--output-dir` defaults from `specs/002-actual-predicted-dashboard/quickstart.md`
+- [X] T002 Add model/scope/source constants in `scripts/generate_actual_predicted_dashboard.py` for included tokens `GF` and `DT`, excluded token `XGB`, scopes `fs1`/`fs2`/`fs3`, required columns, and output filenames
+- [X] T003 [P] Add HTML/CSS/JavaScript template constants in `scripts/generate_actual_predicted_dashboard.py` for two side-by-side panels, selectors, legend, alpha control, and no-data message regions
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Implement reusable data loading, validation, geometry preparation, and manifest helpers that all user stories need.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T004 Implement result-folder discovery in `scripts/generate_actual_predicted_dashboard.py` that includes only `result_partition_k40_compare_GF_fs*` and `result_partition_k40_compare_DT_fs*` and records `result_partition_k40_compare_XGB_fs*` as excluded
+- [X] T005 Implement prediction CSV loading and validation in `scripts/generate_actual_predicted_dashboard.py` for `FEWSNET_admin_code`, `month_start`, `y_true`, and `y_pred_partitioned` with chronological date normalization
+- [X] T006 Implement binary-label validation in `scripts/generate_actual_predicted_dashboard.py` that rejects or records unexpected non-0/1 values without applying any threshold
+- [X] T007 Implement global shapefile loading in `scripts/generate_actual_predicted_dashboard.py` requiring `FEWS_Admin_LZ_v3.shp`, normalizing accepted admin-code aliases to `FEWSNET_admin_code`, repairing invalid geometries when possible, and rejecting Nigeria-only shapefile paths
+- [X] T008 Implement geometry simplification/projection-to-browser payload preparation in `scripts/generate_actual_predicted_dashboard.py` using the global FEWSNET polygons and preserving no-data polygons
+- [X] T009 Implement availability index construction in `scripts/generate_actual_predicted_dashboard.py` keyed by model, scope, and normalized `month_start`
+- [X] T010 Implement manifest assembly and JSON writing in `scripts/generate_actual_predicted_dashboard.py` matching `specs/002-actual-predicted-dashboard/contracts/manifest.schema.json`
+
+**Checkpoint**: The generator can discover valid inputs, validate contracts, prepare geometry/data payloads, and write provenance metadata without rendering the final dashboard.
+
+---
+
+## Phase 3: User Story 1 - Compare actual and predicted crisis maps (Priority: P1) MVP
+
+**Goal**: A user can open one generated dashboard, choose a complete model-scope-month selection, and compare actual labels on the left with partitioned predicted labels on the right over the same geography.
+
+**Independent Test**: Generate the dashboard, open the HTML, select GeoRF fs2 2024-06-01, and verify the left panel displays `y_true` actual crisis distribution while the right panel displays `y_pred_partitioned` predicted crisis distribution for the same geographic canvas.
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Implement dashboard data payload generation in `scripts/generate_actual_predicted_dashboard.py` that maps each `FEWSNET_admin_code` to `y_true` and `y_pred_partitioned` values per model/scope/month
+- [X] T012 [US1] Implement static HTML writing in `scripts/generate_actual_predicted_dashboard.py` that embeds geometry, availability, and label payloads into `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/actual_predicted_dashboard.html` by default
+- [X] T013 [US1] Implement browser-side selection state and map rendering JavaScript in `scripts/generate_actual_predicted_dashboard.py` so both panels update from the same active model/scope/date selection
+- [X] T014 [US1] Implement prediction overlay alpha behavior in `scripts/generate_actual_predicted_dashboard.py` so the left panel defaults to actual-only/prediction alpha 0, the right panel defaults to predicted-visible/prediction alpha 1, and any alpha control updates both panels clearly
+- [X] T015 [US1] Implement fixed crisis color legend and no-data styling in `scripts/generate_actual_predicted_dashboard.py` with `0` as non-crisis, `1` as crisis, and unmatched polygons as no data
+- [X] T016 [US1] Implement explicit panel labels and summary counts in `scripts/generate_actual_predicted_dashboard.py` identifying left as actual/reference and right as predicted/comparison
+- [X] T017 [US1] Run the generator command from `specs/002-actual-predicted-dashboard/quickstart.md` and verify `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/actual_predicted_dashboard.html` exists
+- [ ] T018 [US1] Manually open `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/actual_predicted_dashboard.html` and verify GeoRF fs2 2024-06-01 renders actual left and predicted right without running training, batch workflows, or notebooks
+
+**Checkpoint**: User Story 1 is independently functional as the MVP dashboard comparison.
+
+---
+
+## Phase 4: User Story 2 - Inspect available dates, scopes, and models safely (Priority: P2)
+
+**Goal**: A user can switch among available dates, GeoRF/GeoDT models, and fs1/fs2/fs3 scopes while unavailable or incomplete combinations are omitted or shown with visible no-data messaging.
+
+**Independent Test**: Compare selector options with source folders and `month_start` values, verify GeoXGB/XGBoost never appears, and verify a missing or simulated unavailable combination does not display stale maps.
+
+### Implementation for User Story 2
+
+- [X] T019 [US2] Implement model selector population in `scripts/generate_actual_predicted_dashboard.py` from the availability index with exactly GeoRF and GeoDT when available and no GeoXGB/XGBoost option
+- [X] T020 [US2] Implement scope selector population in `scripts/generate_actual_predicted_dashboard.py` for available fs1/fs2/fs3 combinations only
+- [X] T021 [US2] Implement date selector population in `scripts/generate_actual_predicted_dashboard.py` using normalized `month_start` values sorted chronologically
+- [X] T022 [US2] Implement visible no-data and incomplete-data messages in `scripts/generate_actual_predicted_dashboard.py` for missing rows, unmatched joins, or unavailable selections, clearing stale map state before showing the message
+- [X] T023 [US2] Update manifest warnings in `scripts/generate_actual_predicted_dashboard.py` to record omitted folders, missing required columns, unmatched polygons, and excluded XGB source paths
+- [X] T024 [US2] Run the generator and inspect `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/manifest.json` to verify available models, scopes, dates, XGB exclusions, and no-data warnings are recorded
+- [ ] T025 [US2] Manually verify selector behavior in `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/actual_predicted_dashboard.html`, including no GeoXGB/XGBoost option and no stale maps after unavailable selections
+
+**Checkpoint**: User Story 2 is independently functional for safe selector-driven exploration.
+
+---
+
+## Phase 5: User Story 3 - Preserve provenance and output boundaries (Priority: P3)
+
+**Goal**: A maintainer can review generated artifacts and confirm source files, shapefile, join key, model exclusions, value meanings, threshold contract, smoke-test result, and exploratory output boundaries.
+
+**Independent Test**: Read the generated manifest and verify it documents all included prediction files, XGB exclusions, global shapefile path, `FEWSNET_admin_code` join key, binary label meaning, no-threshold contract, output path, and exploratory workflow status.
+
+### Implementation for User Story 3
+
+- [X] T026 [US3] Implement smoke-test selection logic in `scripts/generate_actual_predicted_dashboard.py` that validates at least one GeoRF or GeoDT fs1/fs2/fs3 month has both actual/predicted data and a non-empty shapefile join
+- [X] T027 [US3] Write manifest fields in `scripts/generate_actual_predicted_dashboard.py` for workflow mode, production status, source directory, included source files, excluded XGB sources, shapefile path, join key, available models/scopes/dates, label contract, threshold contract, output HTML, optional assets, smoke-test result, and warnings
+- [X] T028 [US3] Add output-boundary validation in `scripts/generate_actual_predicted_dashboard.py` to keep generated dashboard files under `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/` by default and avoid overwriting source CSVs or standard deliverable directories
+- [X] T029 [US3] Add optional asset manifesting in `scripts/generate_actual_predicted_dashboard.py` so any extracted asset files remain under the exploratory output directory and are listed in `manifest.json`
+- [X] T030 [US3] Validate `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/manifest.json` against `specs/002-actual-predicted-dashboard/contracts/manifest.schema.json` using a local JSON-schema-capable validator if available or by manual field inspection if not
+- [X] T031 [US3] Verify generated outputs overwrite zero files under `deliverables/`, `prediction_pipeline/`, standard forecast result directories, standalone prediction deliverables, and synthetic scenario deliverables
+
+**Checkpoint**: User Story 3 is independently functional for provenance and artifact-hygiene review.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, documentation alignment, and cleanup across all user stories.
+
+- [X] T032 [P] Update `specs/002-actual-predicted-dashboard/quickstart.md` if the final generator command, output filenames, or validation steps differ from the planned command
+- [X] T033 [P] Review `scripts/generate_actual_predicted_dashboard.py` for ASCII-safe console output, no notebook dependencies, no batch launcher assumptions, and no model-training calls
+- [X] T034 Run a final smoke generation using `scripts/generate_actual_predicted_dashboard.py` and record the validated output paths and selected smoke-test combination in `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/manifest.json`
+- [ ] T035 Open `main_ablation_results/march2026_main_backup_month_ind_cont3/actual_predicted_dashboard/actual_predicted_dashboard.html` in a browser and verify dashboard opens with selectors populated in under 30 seconds
+- [X] T036 Inspect `git status --short` and verify generated exploratory outputs remain ignored or intentionally untracked unless explicitly promoted by the user
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational completion; MVP scope.
+- **User Story 2 (Phase 4)**: Depends on Foundational completion and can be developed after or alongside US1, but final selector behavior should be checked against US1 rendering.
+- **User Story 3 (Phase 5)**: Depends on Foundational completion and can be developed after or alongside US1/US2, but final manifest should include all implemented behavior.
+- **Polish (Phase 6)**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 - Compare actual and predicted crisis maps**: Independent after Foundation; delivers MVP dashboard comparison.
+- **US2 - Inspect available dates, scopes, and models safely**: Independent after Foundation; enhances selectors and missing-data behavior.
+- **US3 - Preserve provenance and output boundaries**: Independent after Foundation; enhances manifest, smoke validation, and artifact hygiene.
+
+### Within Each User Story
+
+- Data payload tasks precede HTML/browser rendering tasks.
+- Selector population tasks precede manual selector validation.
+- Manifest field tasks precede schema/manual manifest validation.
+- Generator execution precedes browser and artifact-boundary validation.
+
+## Parallel Opportunities
+
+- T003 can run in parallel with T001-T002 after the file exists.
+- T004-T010 are mostly independent helper implementations in the same file; split only if multiple agents coordinate edits carefully.
+- After Phase 2, US1, US2, and US3 can be implemented in parallel by different agents if they coordinate edits to `scripts/generate_actual_predicted_dashboard.py`.
+- T032 and T033 can run in parallel during polish because they touch different files.
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Implement dashboard data payload generation in scripts/generate_actual_predicted_dashboard.py"
+Task: "Implement fixed crisis color legend and no-data styling in scripts/generate_actual_predicted_dashboard.py"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "Implement model selector population in scripts/generate_actual_predicted_dashboard.py"
+Task: "Implement scope selector population in scripts/generate_actual_predicted_dashboard.py"
+Task: "Implement date selector population in scripts/generate_actual_predicted_dashboard.py"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "Implement smoke-test selection logic in scripts/generate_actual_predicted_dashboard.py"
+Task: "Add output-boundary validation in scripts/generate_actual_predicted_dashboard.py"
+```
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 setup tasks.
+2. Complete Phase 2 foundational discovery, validation, geometry, availability, and manifest helpers.
+3. Complete Phase 3 User Story 1 tasks.
+4. Stop and validate the generated HTML with GeoRF fs2 2024-06-01.
+
+### Incremental Delivery
+
+1. Setup + Foundation creates a reusable generator skeleton.
+2. US1 delivers the core actual-vs-predicted dashboard.
+3. US2 adds robust selector and missing-data behavior.
+4. US3 adds complete provenance, smoke-test, and artifact-hygiene guarantees.
+5. Polish validates browser behavior, quickstart accuracy, and git/artifact boundaries.
+
+### Notes
+
+- Every task uses project-relative file paths for implementation targets.
+- Do not add formal test tasks unless the user later requests TDD or a test suite.
+- Do not create a backend server, Dash app, notebook, or new batch launcher.
+- Do not run model training or full batch workflows.


### PR DESCRIPTION
## Summary
- Add a static actual-vs-predicted dashboard generator for GeoRF/GeoDT month-ind outputs.
- Add Spec Kit feature artifacts covering requirements, contracts, data model, quickstart, and tasks.
- Update ignore rules for local build/editor artifacts while allowing Spec Kit JSON schemas.

## Test plan
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [ ] Run dashboard generator against local model outputs
- [ ] Open generated dashboard in a browser and verify selectors/panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)