### PR TITLE
Add phase-change monthly performance analysis

### DIFF
--- a/scripts/plot_phase_change_monthly_performance.py
+++ b/scripts/plot_phase_change_monthly_performance.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.lines import Line2D
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ABLATION_ROOT = Path("main_ablation_results/march2026_main_backup_month_ind_cont3")
+DEFAULT_OUTPUT_DIR_NAME = "phase_change_monthly_performance"
+STANDARD_OUTPUT_DIR_NAME = "monthly_performance_plots"
+
+MODEL_CONFIG = {
+    "georf": {
+        "label": "GeoRF",
+        "phase_label": "GeoRF(phase change)",
+        "token": "GF",
+        "color": "#1f77b4",
+        "filename": "georf_phase_change_monthly_performance.png",
+    },
+    "geodt": {
+        "label": "GeoDT",
+        "phase_label": "GeoDT(phase change)",
+        "token": "DT",
+        "color": "#d62728",
+        "filename": "geodt_phase_change_monthly_performance.png",
+    },
+}
+SCOPES = ("fs1", "fs2", "fs3")
+SCOPE_LAG_MONTHS = {"fs1": 4, "fs2": 8, "fs3": 12}
+REQUIRED_COLUMNS = (
+    "FEWSNET_admin_code",
+    "month_start",
+    "y_true",
+    "y_pred_pooled",
+    "y_pred_partitioned",
+)
+OPTIONAL_AUDIT_COLUMNS = ("partition_id",)
+METRICS = (("precision", "Precision"), ("recall", "Recall"), ("f1", "F1"))
+SERIES_COLUMNS = {
+    "partitioned": "y_pred_partitioned",
+    "pooled": "y_pred_pooled",
+}
+OUTPUT_FILES = {
+    "monthly_metrics": "metrics_monthly_phase_change.csv",
+    "summary": "summary_phase_change.xlsx",
+    "audit": "filtered_predictions_phase_change.csv",
+    "manifest": "phase_change_manifest.json",
+}
+SMOKE_PLOT_TEMPLATE = "smoke_{model}_{scope}_phase_change_monthly_performance.png"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate phase-change-only monthly performance diagnostics from row-level predictions."
+    )
+    parser.add_argument("--ablation-root", type=Path, default=DEFAULT_ABLATION_ROOT)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--model", choices=("georf", "geodt", "all"), default="all")
+    parser.add_argument("--scope", choices=("fs1", "fs2", "fs3", "all"), default="all")
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--write-audit", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def resolve_path(path: Path) -> Path:
+    raw = str(path)
+    match = re.match(r"^([A-Za-z]):[\\/](.*)$", raw)
+    if match:
+        drive, rest = match.groups()
+        return Path("/mnt") / drive.lower() / rest.replace("\\", "/")
+    path = path.expanduser()
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def relative_path(path: Path | str) -> str:
+    path = Path(path)
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def selected_models(model_arg: str) -> list[str]:
+    return list(MODEL_CONFIG) if model_arg == "all" else [model_arg]
+
+
+def selected_scopes(scope_arg: str) -> list[str]:
+    return list(SCOPES) if scope_arg == "all" else [scope_arg]
+
+
+def validate_output_dir(ablation_root: Path, output_dir: Path) -> None:
+    standard_output = (ablation_root / STANDARD_OUTPUT_DIR_NAME).resolve()
+    requested = output_dir.resolve()
+    if requested == standard_output:
+        raise ValueError(f"Output directory must not be the standard diagnostics directory: {standard_output}")
+
+
+def prediction_path(ablation_root: Path, model_key: str, scope: str) -> Path:
+    token = MODEL_CONFIG[model_key]["token"]
+    return ablation_root / f"result_partition_k40_compare_{token}_{scope}" / "predictions_monthly.csv"
+
+
+def discover_included_sources(ablation_root: Path, models: list[str], scopes: list[str]) -> list[dict[str, Any]]:
+    sources = []
+    for model_key in models:
+        for scope in scopes:
+            path = prediction_path(ablation_root, model_key, scope)
+            if path.exists():
+                config = MODEL_CONFIG[model_key]
+                sources.append(
+                    {
+                        "path": path,
+                        "model_key": model_key,
+                        "model_label": config["label"],
+                        "source_token": config["token"],
+                        "scope": scope,
+                    }
+                )
+    if not sources:
+        raise FileNotFoundError("No GeoRF or GeoDT prediction files found for the requested selection")
+    return sources
+
+
+def discover_excluded_sources(ablation_root: Path) -> list[str]:
+    patterns = (
+        "result_partition_k40_compare_XGB_fs*/predictions_monthly.csv",
+        "result_partition_k40_compare_GeoXGB_fs*/predictions_monthly.csv",
+        "*XGBoost*/predictions_monthly.csv",
+    )
+    paths = set()
+    for pattern in patterns:
+        paths.update(ablation_root.glob(pattern))
+    return [relative_path(path) for path in sorted(paths)]
+
+
+def require_columns(df: pd.DataFrame, source: Path) -> None:
+    missing = sorted(set(REQUIRED_COLUMNS) - set(df.columns))
+    if missing:
+        raise ValueError(f"Missing required columns in {source}: {missing}")
+
+
+def validate_binary_column(df: pd.DataFrame, column: str, source: Path) -> None:
+    values = pd.to_numeric(df[column], errors="coerce")
+    if values.isna().any():
+        raise ValueError(f"Column {column} contains non-binary or missing values in {source}")
+    unique_values = set(values.astype(int).unique())
+    if not unique_values.issubset({0, 1}):
+        raise ValueError(f"Column {column} must contain only 0/1 values in {source}; found {sorted(unique_values)}")
+    df[column] = values.astype(int)
+
+
+def validate_and_prepare_source(df: pd.DataFrame, source: Path) -> pd.DataFrame:
+    require_columns(df, source)
+    df = df.copy()
+    parsed_dates = pd.to_datetime(df["month_start"], errors="coerce")
+    if parsed_dates.isna().any():
+        raise ValueError(f"Column month_start contains unparseable dates in {source}")
+    df["month_start"] = parsed_dates.dt.to_period("M").dt.to_timestamp()
+    for column in ("y_true", "y_pred_pooled", "y_pred_partitioned"):
+        validate_binary_column(df, column, source)
+    return df
+
+
+def load_sources(sources: list[dict[str, Any]]) -> tuple[pd.DataFrame, list[dict[str, Any]]]:
+    frames = []
+    source_manifest = []
+    for source in sources:
+        path = source["path"]
+        df = pd.read_csv(path)
+        df = validate_and_prepare_source(df, path)
+        df["model_key"] = source["model_key"]
+        df["model_label"] = source["model_label"]
+        df["source_token"] = source["source_token"]
+        df["scope"] = source["scope"]
+        df["source_file"] = relative_path(path)
+        frames.append(df)
+        source_manifest.append(
+            {
+                "path": relative_path(path),
+                "model_key": source["model_key"],
+                "model_label": source["model_label"],
+                "source_token": source["source_token"],
+                "scope": source["scope"],
+                "row_count_before": int(len(df)),
+                "months": [m.strftime("%Y-%m-%d") for m in sorted(df["month_start"].unique())],
+            }
+        )
+    return pd.concat(frames, ignore_index=True), source_manifest
+
+
+def detect_duplicates(df: pd.DataFrame) -> dict[str, Any]:
+    keys = ["model_key", "scope", "FEWSNET_admin_code", "month_start"]
+    duplicate_mask = df.duplicated(keys, keep=False)
+    duplicate_rows = df.loc[duplicate_mask, keys]
+    examples = []
+    if not duplicate_rows.empty:
+        counts = duplicate_rows.groupby(keys).size().reset_index(name="row_count")
+        for record in counts.head(25).to_dict("records"):
+            record["month_start"] = record["month_start"].strftime("%Y-%m-%d")
+            examples.append(record)
+    return {
+        "has_duplicates": bool(duplicate_mask.any()),
+        "duplicate_row_count": int(duplicate_mask.sum()),
+        "duplicate_group_count": int(len(examples)) if duplicate_rows.empty else int(duplicate_rows.groupby(keys).ngroups),
+        "examples": examples,
+    }
+
+
+def add_phase_change_fields(df: pd.DataFrame) -> pd.DataFrame:
+    sort_columns = ["model_key", "scope", "FEWSNET_admin_code", "month_start"]
+    df = df.sort_values(sort_columns).reset_index(drop=True).copy()
+    groups = df.groupby(["model_key", "scope", "FEWSNET_admin_code"], sort=False)
+    df["previous_month_start"] = groups["month_start"].shift(1)
+    df["previous_y_true"] = groups["y_true"].shift(1)
+    df["is_first_observation"] = df["previous_y_true"].isna()
+    df["phase_change"] = (~df["is_first_observation"]) & (df["y_true"] != df["previous_y_true"])
+    return df
+
+
+def build_row_counts(df: pd.DataFrame) -> dict[str, Any]:
+    counts = {}
+    for (model_key, scope), group in df.groupby(["model_key", "scope"], sort=True):
+        before = int(len(group))
+        first = int(group["is_first_observation"].sum())
+        after = int(group["phase_change"].sum())
+        counts[f"{model_key}_{scope}"] = {
+            "model_key": model_key,
+            "model_label": MODEL_CONFIG[model_key]["label"],
+            "scope": scope,
+            "before_filter": before,
+            "first_observation_excluded": first,
+            "non_change_excluded": before - first - after,
+            "after_filter": after,
+        }
+    return counts
+
+
+def metric_values(y_true: pd.Series, y_pred: pd.Series) -> tuple[dict[str, Any], list[tuple[str, str]]]:
+    true = y_true.astype(int)
+    pred = y_pred.astype(int)
+    tp = int(((true == 1) & (pred == 1)).sum())
+    fp = int(((true == 0) & (pred == 1)).sum())
+    fn = int(((true == 1) & (pred == 0)).sum())
+    support = int((true == 1).sum())
+    phase_change_rows = int(len(true))
+    predicted_positive = tp + fp
+    actual_positive = tp + fn
+    undefined = []
+
+    precision = np.nan
+    if predicted_positive == 0:
+        undefined.append(("precision", "zero predicted positive rows (tp + fp = 0)"))
+    else:
+        precision = tp / predicted_positive
+
+    recall = np.nan
+    if actual_positive == 0:
+        undefined.append(("recall", "zero actual positive rows (tp + fn = 0)"))
+    else:
+        recall = tp / actual_positive
+
+    f1 = np.nan
+    if np.isnan(precision) or np.isnan(recall):
+        undefined.append(("f1", "precision or recall is undefined"))
+    elif precision + recall == 0:
+        undefined.append(("f1", "zero precision plus recall denominator"))
+    else:
+        f1 = 2 * precision * recall / (precision + recall)
+
+    return (
+        {
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "phase_change_rows": phase_change_rows,
+            "true_positive_count": tp,
+            "false_positive_count": fp,
+            "false_negative_count": fn,
+            "support": support,
+            "predicted_positive_count": predicted_positive,
+        },
+        undefined,
+    )
+
+
+def add_zero_denominator_records(
+    records: list[dict[str, Any]],
+    undefined: list[tuple[str, str]],
+    level: str,
+    model_key: str,
+    model_label: str,
+    scope: str,
+    series: str,
+    month_start: pd.Timestamp | None,
+) -> None:
+    for metric, reason in undefined:
+        record = {
+            "level": level,
+            "model_key": model_key,
+            "model_label": model_label,
+            "scope": scope,
+            "series": series,
+            "metric": metric,
+            "reason": reason,
+        }
+        if month_start is not None:
+            record["month_start"] = month_start.strftime("%Y-%m-%d")
+        records.append(record)
+
+
+def compute_monthly_metrics(phase_rows: pd.DataFrame) -> tuple[pd.DataFrame, list[dict[str, Any]]]:
+    records = []
+    zero_denominator_records = []
+    if phase_rows.empty:
+        return pd.DataFrame(), zero_denominator_records
+    grouping = ["model_key", "model_label", "scope", "month_start"]
+    for (model_key, model_label, scope, month_start), group in phase_rows.groupby(grouping, sort=True):
+        for series, column in SERIES_COLUMNS.items():
+            values, undefined = metric_values(group["y_true"], group[column])
+            records.append(
+                {
+                    "model_key": model_key,
+                    "model_label": model_label,
+                    "scope": scope,
+                    "month_start": month_start.strftime("%Y-%m-%d"),
+                    "series": series,
+                    **values,
+                }
+            )
+            add_zero_denominator_records(
+                zero_denominator_records,
+                undefined,
+                "monthly",
+                model_key,
+                model_label,
+                scope,
+                series,
+                month_start,
+            )
+    return pd.DataFrame(records), zero_denominator_records
+
+
+def compute_summary_metrics(phase_rows: pd.DataFrame) -> tuple[pd.DataFrame, list[dict[str, Any]]]:
+    records = []
+    zero_denominator_records = []
+    if phase_rows.empty:
+        return pd.DataFrame(), zero_denominator_records
+    grouping = ["model_key", "model_label", "scope"]
+    for (model_key, model_label, scope), group in phase_rows.groupby(grouping, sort=True):
+        for series, column in SERIES_COLUMNS.items():
+            values, undefined = metric_values(group["y_true"], group[column])
+            records.append(
+                {
+                    "model_key": model_key,
+                    "model_label": MODEL_CONFIG[model_key]["phase_label"],
+                    "base_model_label": model_label,
+                    "scope": scope,
+                    "lag_months": SCOPE_LAG_MONTHS[scope],
+                    "series": series,
+                    **values,
+                }
+            )
+            add_zero_denominator_records(
+                zero_denominator_records,
+                undefined,
+                "summary",
+                model_key,
+                MODEL_CONFIG[model_key]["phase_label"],
+                scope,
+                series,
+                None,
+            )
+    return pd.DataFrame(records), zero_denominator_records
+
+
+def find_no_phase_change_months(df: pd.DataFrame, phase_rows: pd.DataFrame) -> list[dict[str, Any]]:
+    records = []
+    phase_months = set()
+    if not phase_rows.empty:
+        phase_months = set(
+            (row.model_key, row.scope, row.month_start)
+            for row in phase_rows[["model_key", "scope", "month_start"]].drop_duplicates().itertuples(index=False)
+        )
+    for row in df[["model_key", "scope", "month_start"]].drop_duplicates().itertuples(index=False):
+        if (row.model_key, row.scope, row.month_start) not in phase_months:
+            records.append(
+                {
+                    "model_key": row.model_key,
+                    "scope": row.scope,
+                    "month_start": row.month_start.strftime("%Y-%m-%d"),
+                    "reason": "no retained phase-change rows",
+                }
+            )
+    return records
+
+
+def render_phase_change_plot(
+    metrics_df: pd.DataFrame,
+    model_key: str,
+    scopes: list[str],
+    output_path: Path | None = None,
+    smoke: bool = False,
+) -> None:
+    config = MODEL_CONFIG[model_key]
+    fig, axes = plt.subplots(len(scopes), len(METRICS), figsize=(17, 3.2 * len(scopes) + 1.4), squeeze=False)
+    for row_index, scope in enumerate(scopes):
+        scoped = metrics_df[(metrics_df["model_key"] == model_key) & (metrics_df["scope"] == scope)]
+        months = sorted(scoped["month_start"].dropna().unique(), key=lambda m: pd.Period(m, freq="M"))
+        x = np.arange(len(months))
+        for col_index, (metric, metric_label) in enumerate(METRICS):
+            ax = axes[row_index][col_index]
+            if months:
+                for series, linestyle, marker in (("partitioned", "-", "o"), ("pooled", "--", "s")):
+                    series_df = scoped[scoped["series"] == series].set_index("month_start")
+                    values = [pd.to_numeric(series_df.loc[month, metric], errors="coerce") if month in series_df.index else np.nan for month in months]
+                    ax.plot(
+                        x,
+                        values,
+                        color=config["color"],
+                        linestyle=linestyle,
+                        marker=marker,
+                        linewidth=2,
+                        alpha=0.9 if series == "partitioned" else 0.75,
+                        label=series,
+                    )
+                ax.set_xticks(x)
+                ax.set_xticklabels(months, rotation=45, ha="right")
+            else:
+                ax.text(0.5, 0.5, "No phase-change rows", ha="center", va="center", transform=ax.transAxes)
+                ax.set_xticks([])
+            ax.set_ylim(0, 1)
+            ax.grid(True, alpha=0.25)
+            if row_index == 0:
+                ax.set_title(metric_label)
+            if col_index == 0:
+                ax.set_ylabel(f"{scope}\nMetric value")
+            if row_index == len(scopes) - 1:
+                ax.set_xlabel("Test month")
+    legend_handles = [
+        Line2D([0], [0], color=config["color"], linestyle="-", marker="o", linewidth=2, label="partitioned"),
+        Line2D([0], [0], color=config["color"], linestyle="--", marker="s", linewidth=2, alpha=0.75, label="pooled"),
+    ]
+    mode_label = "smoke" if smoke else "exploratory"
+    fig.suptitle(f"{config['label']} phase-change-only monthly crisis-class performance ({mode_label})", fontsize=16)
+    fig.legend(handles=legend_handles, loc="lower center", ncol=2, frameon=False)
+    fig.tight_layout(rect=(0, 0.07, 1, 0.93))
+    if output_path is not None:
+        fig.savefig(output_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+
+
+def prepare_artifact_paths(output_dir: Path, models: list[str], write_audit: bool) -> dict[str, list[str]]:
+    full = [str(output_dir / MODEL_CONFIG[model]["filename"]) for model in models]
+    full.extend(
+        [
+            str(output_dir / OUTPUT_FILES["monthly_metrics"]),
+            str(output_dir / OUTPUT_FILES["summary"]),
+            str(output_dir / OUTPUT_FILES["manifest"]),
+        ]
+    )
+    if write_audit:
+        full.append(str(output_dir / OUTPUT_FILES["audit"]))
+    return {"full": full}
+
+
+def serialize_manifest(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): serialize_manifest(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [serialize_manifest(item) for item in value]
+    if isinstance(value, tuple):
+        return [serialize_manifest(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, pd.Timestamp):
+        return value.strftime("%Y-%m-%d")
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        return None if np.isnan(value) else float(value)
+    if isinstance(value, float) and np.isnan(value):
+        return None
+    return value
+
+
+def build_manifest(
+    mode: str,
+    ablation_root: Path,
+    output_dir: Path,
+    models: list[str],
+    scopes: list[str],
+    source_manifest: list[dict[str, Any]],
+    excluded_sources: list[str],
+    row_counts: dict[str, Any],
+    duplicate_flags: dict[str, Any],
+    no_phase_change_months: list[dict[str, Any]],
+    zero_denominator_metrics: list[dict[str, Any]],
+    generated_artifacts: list[str],
+    planned_artifacts: list[str],
+) -> dict[str, Any]:
+    return {
+        "workflow_mode": "exploratory diagnostics / baseline-comparison analysis",
+        "status": "exploratory",
+        "mode": mode,
+        "entry_point": "scripts/plot_phase_change_monthly_performance.py",
+        "source_root": str(ablation_root),
+        "output_dir": str(output_dir),
+        "model_selection": models,
+        "scope_selection": scopes,
+        "included_source_files": source_manifest,
+        "excluded_source_files": excluded_sources,
+        "column_contract": {
+            "required": list(REQUIRED_COLUMNS),
+            "optional_audit": list(OPTIONAL_AUDIT_COLUMNS),
+            "spatial_key": "FEWSNET_admin_code",
+            "test_month": "month_start",
+            "true_label": "y_true",
+            "prediction_columns": SERIES_COLUMNS,
+        },
+        "filter_definition": {
+            "grouping": ["model_key", "scope", "FEWSNET_admin_code"],
+            "ordering": "month_start ascending within each group",
+            "previous_period": "previous available test month, not strict previous calendar month",
+            "first_observation": "excluded because no previous y_true exists",
+            "phase_change": "retain rows where y_true differs from previous_y_true",
+        },
+        "row_counts": row_counts,
+        "duplicate_flags": duplicate_flags,
+        "no_phase_change_months": no_phase_change_months,
+        "zero_denominator_metrics": zero_denominator_metrics,
+        "generated_artifacts": generated_artifacts,
+        "planned_artifacts": planned_artifacts,
+    }
+
+
+def print_console_summary(manifest: dict[str, Any], summary_df: pd.DataFrame) -> None:
+    print("Phase-change monthly performance analysis")
+    print(f"Mode: {manifest['mode']}")
+    print(f"Included source files: {len(manifest['included_source_files'])}")
+    print(f"Excluded XGB source files: {len(manifest['excluded_source_files'])}")
+    print(f"Output directory: {manifest['output_dir']}")
+    for key in sorted(manifest["row_counts"]):
+        counts = manifest["row_counts"][key]
+        print(
+            f"{key}: before={counts['before_filter']} first_excluded={counts['first_observation_excluded']} "
+            f"non_change_excluded={counts['non_change_excluded']} after={counts['after_filter']}"
+        )
+    print(f"Duplicate row groups flagged: {manifest['duplicate_flags']['duplicate_group_count']}")
+    print(f"Zero-denominator metrics: {len(manifest['zero_denominator_metrics'])}")
+    if manifest["mode"] == "dry-run":
+        for artifact in manifest["planned_artifacts"]:
+            print(f"Planned: {artifact}")
+    else:
+        for artifact in manifest["generated_artifacts"]:
+            print(f"Generated: {artifact}")
+    if manifest["mode"] == "smoke" and not summary_df.empty:
+        row = summary_df.head(1).replace({np.nan: None}).to_dict("records")[0]
+        print("Draft summary row:")
+        print(json.dumps(serialize_manifest(row), sort_keys=True))
+
+
+def write_full_outputs(
+    output_dir: Path,
+    models: list[str],
+    metrics_df: pd.DataFrame,
+    summary_df: pd.DataFrame,
+    phase_rows: pd.DataFrame,
+    manifest: dict[str, Any],
+    write_audit: bool,
+) -> list[str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated_artifacts = []
+    for model_key in models:
+        path = output_dir / MODEL_CONFIG[model_key]["filename"]
+        render_phase_change_plot(metrics_df, model_key, list(SCOPES), path)
+        generated_artifacts.append(str(path))
+    metrics_path = output_dir / OUTPUT_FILES["monthly_metrics"]
+    summary_path = output_dir / OUTPUT_FILES["summary"]
+    manifest_path = output_dir / OUTPUT_FILES["manifest"]
+    metrics_df.to_csv(metrics_path, index=False)
+    summary_df.to_excel(summary_path, index=False, sheet_name="phase_change_summary")
+    generated_artifacts.extend([str(metrics_path), str(summary_path)])
+    if write_audit:
+        audit_path = output_dir / OUTPUT_FILES["audit"]
+        audit_columns = [
+            "model_key",
+            "model_label",
+            "source_token",
+            "scope",
+            "source_file",
+            "FEWSNET_admin_code",
+            "month_start",
+            "previous_month_start",
+            "previous_y_true",
+            "is_first_observation",
+            "phase_change",
+            "y_true",
+            "y_pred_pooled",
+            "y_pred_partitioned",
+        ]
+        if "partition_id" in phase_rows.columns:
+            audit_columns.insert(7, "partition_id")
+        audit_df = phase_rows[audit_columns].copy()
+        audit_df["month_start"] = audit_df["month_start"].dt.strftime("%Y-%m-%d")
+        audit_df["previous_month_start"] = audit_df["previous_month_start"].dt.strftime("%Y-%m-%d")
+        audit_df["previous_y_true"] = audit_df["previous_y_true"].astype(int)
+        audit_df.to_csv(audit_path, index=False)
+        generated_artifacts.append(str(audit_path))
+    manifest["generated_artifacts"] = generated_artifacts + [str(manifest_path)]
+    manifest_path.write_text(json.dumps(serialize_manifest(manifest), indent=2), encoding="utf-8")
+    generated_artifacts.append(str(manifest_path))
+    return generated_artifacts
+
+
+def run_analysis(args: argparse.Namespace) -> tuple[dict[str, Any], pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    if args.dry_run and args.smoke:
+        raise ValueError("Use only one of --dry-run or --smoke")
+    if args.smoke and (args.model == "all" or args.scope == "all"):
+        raise ValueError("Smoke mode requires one model and one scope, for example --model georf --scope fs1")
+
+    ablation_root = resolve_path(args.ablation_root)
+    output_dir = resolve_path(args.output_dir) if args.output_dir is not None else ablation_root / DEFAULT_OUTPUT_DIR_NAME
+    validate_output_dir(ablation_root, output_dir)
+    models = selected_models(args.model)
+    scopes = selected_scopes(args.scope)
+    mode = "dry-run" if args.dry_run else "smoke" if args.smoke else "full"
+
+    sources = discover_included_sources(ablation_root, models, scopes)
+    excluded_sources = discover_excluded_sources(ablation_root)
+    source_df, source_manifest = load_sources(sources)
+    duplicate_flags = detect_duplicates(source_df)
+    prepared_df = add_phase_change_fields(source_df)
+    phase_rows = prepared_df[prepared_df["phase_change"]].copy()
+    if not phase_rows.empty:
+        phase_rows["previous_y_true"] = phase_rows["previous_y_true"].astype(int)
+    row_counts = build_row_counts(prepared_df)
+    for source in source_manifest:
+        key = f"{source['model_key']}_{source['scope']}"
+        source.update(row_counts[key])
+    metrics_df, monthly_zero_denominators = compute_monthly_metrics(phase_rows)
+    summary_df, summary_zero_denominators = compute_summary_metrics(phase_rows)
+    zero_denominator_metrics = monthly_zero_denominators + summary_zero_denominators
+    no_phase_change_months = find_no_phase_change_months(prepared_df, phase_rows)
+    planned_artifacts = prepare_artifact_paths(output_dir, models, args.write_audit)["full"]
+    generated_artifacts: list[str] = []
+
+    manifest = build_manifest(
+        mode,
+        ablation_root,
+        output_dir,
+        models,
+        scopes,
+        source_manifest,
+        excluded_sources,
+        row_counts,
+        duplicate_flags,
+        no_phase_change_months,
+        zero_denominator_metrics,
+        generated_artifacts,
+        planned_artifacts,
+    )
+
+    if mode == "smoke":
+        output_dir.mkdir(parents=True, exist_ok=True)
+        smoke_path = output_dir / SMOKE_PLOT_TEMPLATE.format(model=models[0], scope=scopes[0])
+        render_phase_change_plot(metrics_df, models[0], scopes, smoke_path, smoke=True)
+        generated_artifacts.append(str(smoke_path))
+        manifest["generated_artifacts"] = generated_artifacts
+    elif mode == "full":
+        write_full_outputs(output_dir, models, metrics_df, summary_df, phase_rows, manifest, args.write_audit)
+
+    return manifest, metrics_df, summary_df, phase_rows
+
+
+def main() -> int:
+    args = parse_args()
+    manifest, _, summary_df, _ = run_analysis(args)
+    print_console_summary(manifest, summary_df)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/003-phase-change-performance/checklists/requirements.md
+++ b/specs/003-phase-change-performance/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Phase-Change Monthly Performance
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on 2026-05-15.
+- The specification includes source column names and folder tokens as data-contract requirements because the user explicitly requested source inspection before implementation.
+- No clarification markers remain; the feature is ready for `/speckit-plan`.

--- a/specs/003-phase-change-performance/contracts/phase-change-analysis-cli.md
+++ b/specs/003-phase-change-performance/contracts/phase-change-analysis-cli.md
@@ -1,0 +1,89 @@
+# Contract: Phase-Change Analysis CLI
+
+## Purpose
+
+Define the user-facing command contract for generating phase-change-only monthly performance diagnostics from existing row-level prediction files.
+
+## Command
+
+```bash
+python3 scripts/plot_phase_change_monthly_performance.py [options]
+```
+
+## Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--ablation-root PATH` | No | `main_ablation_results/march2026_main_backup_month_ind_cont3` | Source root containing `result_partition_k40_compare_{GF,DT}_fs{1,2,3}/predictions_monthly.csv` files. |
+| `--output-dir PATH` | No | `<ablation-root>/phase_change_monthly_performance` | Destination for phase-change-only generated outputs. Must not be `monthly_performance_plots`. |
+| `--model {georf,geodt,all}` | No | `all` | Model family selection. `all` includes GeoRF and GeoDT only. |
+| `--scope {fs1,fs2,fs3,all}` | No | `all` | Forecasting scope selection. Full mode should include fs1, fs2, and fs3. |
+| `--smoke` | No | false | Run a reduced validation path, rendering one reduced plot and draft summary row without producing the full artifact set. |
+| `--dry-run` | No | false | Validate input discovery, column contracts, filtering counts, and planned outputs without writing generated artifacts. |
+| `--write-audit` | No | true | Write filtered row-level audit output in full mode. |
+
+## Input Contract
+
+For each included source file, required columns are:
+
+- `FEWSNET_admin_code`
+- `month_start`
+- `y_true`
+- `y_pred_pooled`
+- `y_pred_partitioned`
+
+Optional audit column:
+
+- `partition_id`
+
+Included source folders:
+
+- `result_partition_k40_compare_GF_fs1`
+- `result_partition_k40_compare_GF_fs2`
+- `result_partition_k40_compare_GF_fs3`
+- `result_partition_k40_compare_DT_fs1`
+- `result_partition_k40_compare_DT_fs2`
+- `result_partition_k40_compare_DT_fs3`
+
+Excluded source folders:
+
+- Any `result_partition_k40_compare_XGB_fs*` folder.
+- Any GeoXGB/XGBoost tokened source.
+
+## Output Contract
+
+Full mode writes the following to `--output-dir`:
+
+- `georf_phase_change_monthly_performance.png`
+- `geodt_phase_change_monthly_performance.png`
+- `metrics_monthly_phase_change.csv`
+- `summary_phase_change.xlsx`
+- `filtered_predictions_phase_change.csv` when audit output is enabled
+- `phase_change_manifest.json`
+
+Smoke mode must demonstrate:
+
+- one included model/scope subset,
+- first-observation exclusion,
+- before/after row counts,
+- recomputed precision, recall, and F1,
+- one reduced plot in memory or a clearly labeled smoke output,
+- one draft summary row.
+
+Dry-run mode must not write generated artifacts.
+
+## Validation Contract
+
+The command must fail with a clear message when:
+
+- an included file is missing required columns,
+- no GeoRF or GeoDT prediction files can be found,
+- `--output-dir` resolves to the existing `monthly_performance_plots` directory,
+- `--dry-run` and `--smoke` are both requested.
+
+The command must record in the manifest when:
+
+- XGB files are found and excluded,
+- duplicate `(model, scope, FEWSNET_admin_code, month_start)` rows are detected,
+- a month has no retained phase-change rows,
+- any metric is blank/NA because of a zero denominator.

--- a/specs/003-phase-change-performance/data-model.md
+++ b/specs/003-phase-change-performance/data-model.md
@@ -1,0 +1,152 @@
+# Data Model: Phase-Change Monthly Performance
+
+## Entity: Source Prediction File
+
+Represents one row-level `predictions_monthly.csv` input for a model family and forecasting scope.
+
+### Fields
+
+- `path`: project-relative source file path.
+- `model_key`: canonical model key, `georf` or `geodt`.
+- `model_label`: display label, `GeoRF` or `GeoDT`.
+- `source_token`: folder token, `GF` or `DT`.
+- `scope`: one of `fs1`, `fs2`, `fs3`.
+- `row_count_before`: total source rows read.
+- `row_count_after`: rows retained after phase-change filtering.
+- `first_observation_count`: rows excluded because no previous true value exists.
+
+### Validation Rules
+
+- Must point to a GeoRF/GF or GeoDT/DT `predictions_monthly.csv` file.
+- Must not point to XGB/GeoXGB files.
+- Must contain required columns: `FEWSNET_admin_code`, `month_start`, `y_true`, `y_pred_pooled`, `y_pred_partitioned`.
+- `scope` must remain separate from other scopes.
+
+## Entity: Prediction Row
+
+Represents one spatial unit and test month prediction record.
+
+### Fields
+
+- `FEWSNET_admin_code`: spatial key used for phase-change grouping.
+- `month_start`: test-month date used for chronological ordering.
+- `partition_id`: optional audit context retained from the source file when present.
+- `y_true`: binary true class-1 crisis indicator.
+- `y_pred_pooled`: binary pooled-model prediction.
+- `y_pred_partitioned`: binary partitioned-model prediction.
+- `model_key`: `georf` or `geodt` inherited from the source file.
+- `scope`: `fs1`, `fs2`, or `fs3` inherited from the source file.
+
+### Validation Rules
+
+- `month_start` must be parseable as a date.
+- `y_true`, `y_pred_pooled`, and `y_pred_partitioned` must represent binary class labels.
+- Duplicate `(model_key, scope, FEWSNET_admin_code, month_start)` rows must be flagged in provenance before filtering proceeds or before results are interpreted.
+
+## Entity: Spatial Unit Series
+
+Represents the ordered rows for one `FEWSNET_admin_code` within one model family and forecasting scope.
+
+### Fields
+
+- `model_key`
+- `scope`
+- `FEWSNET_admin_code`
+- `ordered_rows`: rows sorted by `month_start`.
+
+### State Transitions
+
+1. Source rows loaded.
+2. Rows sorted by `month_start`.
+3. First row marked as ineligible due to no previous true value.
+4. Remaining rows marked as phase-change or non-phase-change based on `y_true` compared with the previous available row.
+
+## Entity: Phase-Change Row
+
+Represents a retained prediction row where the true crisis state changed from the previous available test month.
+
+### Fields
+
+- All Prediction Row fields.
+- `previous_month_start`: previous available test month for the same model/scope/spatial unit.
+- `previous_y_true`: true class label from the previous available test month.
+- `phase_change`: true for retained rows.
+
+### Validation Rules
+
+- Must never be the first observed row in its Spatial Unit Series.
+- Must satisfy `y_true != previous_y_true`.
+- Must be computed separately by model family and forecasting scope.
+
+## Entity: Monthly Metric Result
+
+Represents recomputed monthly performance for one result series.
+
+### Fields
+
+- `model_key`
+- `model_label`
+- `scope`
+- `test_month`
+- `series`: `pooled` or `partitioned`.
+- `precision`
+- `recall`
+- `f1`
+- `phase_change_rows`
+- `true_positive_count`
+- `false_positive_count`
+- `false_negative_count`
+- `undefined_metrics`: list or flags for metrics recorded as blank/NA due to zero denominators.
+
+### Validation Rules
+
+- Must be computed from phase-change rows only.
+- Must not use already aggregated monthly metrics as input.
+- Undefined precision, recall, or F1 must be represented as blank/NA and documented in provenance.
+
+## Entity: Summary Table Row
+
+Represents overall phase-change performance for one model, scope, and result series.
+
+### Fields
+
+- `model_label`: `GeoRF(phase change)` or `GeoDT(phase change)`.
+- `lag_months`: 4 for fs1, 8 for fs2, 12 for fs3.
+- `scope`: `fs1`, `fs2`, or `fs3`.
+- `series`: `pooled` or `partitioned`.
+- `precision`
+- `recall`
+- `f1`
+- `phase_change_rows`
+
+### Validation Rules
+
+- Metrics must be recomputed from all filtered phase-change rows pooled across months for the model/scope/series.
+- Must not include XGB, FEWSNET, original population-level, or unrelated baseline rows.
+
+## Entity: Provenance Manifest
+
+Represents audit information for the analysis run.
+
+### Fields
+
+- `workflow_mode`: exploratory diagnostics / baseline-comparison analysis.
+- `status`: exploratory.
+- `source_root`
+- `output_dir`
+- `included_source_files`
+- `excluded_source_files`
+- `column_contract`
+- `filter_definition`
+- `row_counts`
+- `zero_denominator_metrics`
+- `duplicate_month_flags`
+- `generated_artifacts`
+- `smoke_or_full_mode`
+
+### Validation Rules
+
+- Must document all included GeoRF and GeoDT files.
+- Must document excluded XGB files.
+- Must document row counts before and after filtering by model and scope.
+- Must document blank/NA metrics caused by zero denominators.

--- a/specs/003-phase-change-performance/plan.md
+++ b/specs/003-phase-change-performance/plan.md
@@ -1,0 +1,116 @@
+# Implementation Plan: Phase-Change Monthly Performance
+
+**Branch**: `003-phase-change-performance` | **Date**: 2026-05-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-phase-change-performance/spec.md`
+
+**Note**: This plan covers Phase 0 and Phase 1 design only. Implementation tasks are generated separately by `/speckit-tasks`.
+
+## Summary
+
+Create an exploratory phase-change-only monthly performance analysis over existing row-level `predictions_monthly.csv` outputs. The implementation will add a dedicated analysis entry point under `scripts/` that reads GeoRF/GF and GeoDT/DT fs1-fs3 prediction files, excludes XGB, filters rows where `y_true` changes from the previous available test month for each `FEWSNET_admin_code`, recomputes class-1 precision/recall/F1 for pooled and partitioned series, and writes clearly labeled plots, tables, audit files, and provenance under a new phase-change output directory.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+  
+**Primary Dependencies**: pandas, numpy, matplotlib, openpyxl or the repository's existing Excel writer dependency  
+**Storage**: Local CSV, XLSX, PNG, and JSON files under existing repository output directories  
+**Testing**: Smoke/dry-run path over one GeoRF or GeoDT prediction file plus direct validation of row counts, first-row exclusion, metric recomputation, and artifact manifest  
+**Target Platform**: WSL/Linux command execution for development; output paths must also be understandable from the existing Windows project layout  
+**Project Type**: Repository-local exploratory analysis script  
+**Performance Goals**: Process the six in-scope prediction files, each approximately 62k rows, without model training or multi-hour batch execution; smoke mode should run on a reduced file/month subset suitable for quick validation  
+**Constraints**: No model retraining; no notebook execution; no ACTIVE_LAGS, lag-logic, partition-map, or prediction changes; no XGB/GeoXGB inclusion; no FEWSNET or original population-level rows in the summary table; no overwriting `monthly_performance_plots` or standard deliverables; use ASCII-safe CLI/status text if output may be copied into Windows CMD workflows  
+**Scale/Scope**: Six included source files: GeoRF/GF and GeoDT/DT for fs1, fs2, and fs3. Inspected files contain 12 test months from 2021-02-01 through 2024-10-01 and 5,713 spatial units per file, with 62,189 rows per file.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Pipeline Contract**: PASS. Affected workflow is exploratory diagnostics / baseline-comparison analysis. Canonical entry point will be a repository-local script under `scripts/`. Inputs are existing `predictions_monthly.csv` files under `main_ablation_results/march2026_main_backup_month_ind_cont3/result_partition_k40_compare_{GF,DT}_fs{1,2,3}/`. Outputs are phase-change-only plots, recomputed metric tables, optional filtered audit CSVs, and a manifest/README under a new phase-change output directory.
+- **Temporal Integrity**: PASS. The feature uses existing labeled prediction rows only: fs1 = 4 months, fs2 = 8 months, and fs3 = 12 months. The target/test months are the materialized `month_start` rows already present in the prediction files, inspected as 2021-02-01 through 2024-10-01. No feature-month-to-target-month remapping is performed; `ACTIVE_LAGS` and all lag mapping logic remain unchanged. Phase-change comparison uses previous available test month within each spatial unit/model/scope series. Missing FEWSNET publication months and synthetic target rows are not introduced or touched.
+- **Spatial Partitioning**: PASS. No partition maps are created or changed. `partition_id` may be retained for audit context only; phase-change grouping uses `FEWSNET_admin_code`. Existing pooled vs partitioned semantics are read from `y_pred_pooled` and `y_pred_partitioned`.
+- **Threshold & Prediction Contract**: PASS. No prediction thresholds are introduced or changed. The feature analyzes already materialized binary prediction columns and excludes scenario thresholds.
+- **Geographic Scope**: PASS. No map rendering or shapefile joining is in scope. The analysis inherits the geographic coverage of the existing prediction files and must not imply any new shapefile scope.
+- **Crisis-Class Validation**: PASS. Class-1 crisis evidence is recomputed as precision, recall, and F1 using `y_true` as the binary positive crisis label. Smoke validation is required before full artifact generation.
+- **Operational Hygiene**: PASS. Work is performed from WSL/Linux-style commands against existing files; no Windows batch launcher is required. Generated outputs stay under a clearly labeled phase-change directory and should remain out of source control unless explicitly promoted. No notebooks or large scratch artifacts are created.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-phase-change-performance/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── phase-change-analysis-cli.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+scripts/
+├── plot_monthly_performance_metrics.py          # Existing reference style and manifest conventions
+└── plot_phase_change_monthly_performance.py     # New phase-change-only analysis entry point
+
+main_ablation_results/march2026_main_backup_month_ind_cont3/
+├── result_partition_k40_compare_GF_fs1/predictions_monthly.csv
+├── result_partition_k40_compare_GF_fs2/predictions_monthly.csv
+├── result_partition_k40_compare_GF_fs3/predictions_monthly.csv
+├── result_partition_k40_compare_DT_fs1/predictions_monthly.csv
+├── result_partition_k40_compare_DT_fs2/predictions_monthly.csv
+├── result_partition_k40_compare_DT_fs3/predictions_monthly.csv
+├── result_partition_k40_compare_XGB_fs*/predictions_monthly.csv  # excluded and documented
+├── monthly_performance_plots/                                  # existing outputs; do not overwrite
+└── phase_change_monthly_performance/                           # new generated outputs
+    ├── georf_phase_change_monthly_performance.png
+    ├── geodt_phase_change_monthly_performance.png
+    ├── metrics_monthly_phase_change.csv
+    ├── summary_phase_change.xlsx
+    ├── filtered_predictions_phase_change.csv
+    └── phase_change_manifest.json
+```
+
+**Structure Decision**: Use a dedicated script in the existing `scripts/` analysis area and a dedicated generated-output directory under the existing ablation root. This keeps exploratory phase-change artifacts separate from standard `monthly_performance_plots` and avoids adding a new batch launcher.
+
+## Complexity Tracking
+
+No constitution violations are introduced; no complexity exemptions are required.
+
+## Phase 0: Research Summary
+
+See [research.md](research.md). Key decisions:
+
+- Use a dedicated phase-change analysis script rather than extending the existing standard monthly plotter with mode flags.
+- Select only GF/GeoRF and DT/GeoDT prediction folders for fs1, fs2, and fs3; record XGB exclusions.
+- Compare each spatial unit to the previous available test month, not strict previous calendar month.
+- Represent undefined metrics as blank/NA and document zero-denominator reasons in the manifest.
+- Aggregate summary-table metrics by recomputing from all filtered phase-change rows pooled across months for each model, scope, and series.
+
+## Phase 1: Design Summary
+
+See [data-model.md](data-model.md), [contracts/phase-change-analysis-cli.md](contracts/phase-change-analysis-cli.md), and [quickstart.md](quickstart.md).
+
+Implementation design:
+
+1. Resolve the ablation root path and output path without overwriting existing standard outputs.
+2. Discover or explicitly enumerate the six in-scope prediction files.
+3. Validate required source columns: `FEWSNET_admin_code`, `month_start`, `y_true`, `y_pred_pooled`, `y_pred_partitioned`, with optional retention of `partition_id` for audit context.
+4. Sort each model/scope/spatial-unit series by `month_start`, exclude first observations, flag duplicate month ambiguity, and retain only rows where current `y_true` differs from previous available `y_true`.
+5. Recompute monthly metrics for pooled and partitioned predictions using only retained rows, with blank/NA for undefined metrics and manifest entries for zero denominators.
+6. Recompute summary-table metrics from all filtered phase-change rows pooled across months for each model/scope/series.
+7. Render phase-change-only monthly plots using the existing GeoRF/GeoDT colors and fs1-fs3 by metric layout where practical, without FEWSNET series.
+8. Write audit CSVs, summary workbook, plots, and manifest to `phase_change_monthly_performance/`.
+9. Provide smoke/dry-run behavior that validates a reduced source subset before full artifact generation.
+
+## Post-Design Constitution Check
+
+- **Pipeline Contract**: PASS. The planned script, inputs, outputs, and manifest provenance are explicit.
+- **Temporal Integrity**: PASS. The design reads existing labeled prediction rows only, preserves fs1 = 4 months, fs2 = 8 months, and fs3 = 12 months as separate scopes, treats `month_start` as the existing target/test month, performs no feature-month-to-target-month remapping, and changes no lag logic.
+- **Spatial Partitioning**: PASS. No partitioning semantics are changed; pooled and partitioned series are read from existing prediction columns.
+- **Threshold & Prediction Contract**: PASS. No threshold is introduced; existing binary predictions are analyzed as-is.
+- **Geographic Scope**: PASS. No map rendering or shapefile joining is planned.
+- **Crisis-Class Validation**: PASS. The design recomputes class-1 precision, recall, and F1 from filtered row-level labels and predictions.
+- **Operational Hygiene**: PASS. Outputs are isolated under a new generated directory, no notebook execution is planned, and no standard deliverables are overwritten.

--- a/specs/003-phase-change-performance/quickstart.md
+++ b/specs/003-phase-change-performance/quickstart.md
@@ -1,0 +1,78 @@
+# Quickstart: Phase-Change Monthly Performance
+
+## Preconditions
+
+- Work from the repository root.
+- Use the existing Python 3.12 environment with pandas, numpy, matplotlib, and Excel-writing support installed.
+- Do not run model training, batch evaluation, notebooks, or standalone prediction workflows for this feature.
+- Use existing row-level source files under:
+
+```text
+main_ablation_results/march2026_main_backup_month_ind_cont3
+```
+
+## Smoke-test path
+
+Run a reduced validation before generating full outputs:
+
+```bash
+python3 scripts/plot_phase_change_monthly_performance.py --model georf --scope fs1 --smoke
+```
+
+Expected smoke evidence:
+
+- exactly one GeoRF fs1 `predictions_monthly.csv` source is loaded,
+- required columns are validated,
+- first observed row per `FEWSNET_admin_code` is excluded,
+- phase-change rows are counted after comparing `y_true` with the previous available test month,
+- precision, recall, and F1 are recomputed from filtered rows for pooled and partitioned series,
+- one reduced plot and one draft summary row are reported or written to a clearly labeled smoke output,
+- no standard output directory is overwritten.
+
+## Dry run
+
+Validate full input discovery and planned outputs without writing generated artifacts:
+
+```bash
+python3 scripts/plot_phase_change_monthly_performance.py --dry-run
+```
+
+Expected dry-run evidence:
+
+- six included source files are identified: GF and DT for fs1, fs2, and fs3,
+- XGB files are listed as excluded,
+- output directory resolves to `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance`,
+- no files are written.
+
+## Full exploratory analysis
+
+Generate phase-change-only plots, tables, audit files, and manifest:
+
+```bash
+python3 scripts/plot_phase_change_monthly_performance.py
+```
+
+Expected generated outputs:
+
+```text
+main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/
+├── georf_phase_change_monthly_performance.png
+├── geodt_phase_change_monthly_performance.png
+├── metrics_monthly_phase_change.csv
+├── summary_phase_change.xlsx
+├── filtered_predictions_phase_change.csv
+└── phase_change_manifest.json
+```
+
+## Manual validation checklist
+
+After full generation, confirm:
+
+1. `monthly_performance_plots/` timestamps and contents are unchanged.
+2. `phase_change_manifest.json` records included GF/DT source files and excluded XGB files.
+3. Manifest row counts show before-filter, first-observation-excluded, and after-filter counts for each model/scope.
+4. Filtered audit rows all satisfy `y_true != previous_y_true`.
+5. Monthly metrics are recomputed from filtered rows, not from existing `metrics_monthly.csv` files.
+6. Blank/NA metrics caused by zero denominators are listed in the manifest.
+7. `summary_phase_change.xlsx` includes only GeoRF(phase change) and GeoDT(phase change) for fs1, fs2, and fs3.
+8. Plots are clearly labeled as phase-change-only and contain no FEWSNET or XGB series.

--- a/specs/003-phase-change-performance/research.md
+++ b/specs/003-phase-change-performance/research.md
@@ -1,0 +1,64 @@
+# Research: Phase-Change Monthly Performance
+
+## Decision: Use a dedicated phase-change analysis script
+
+**Rationale**: The existing `scripts/plot_monthly_performance_metrics.py` reads already aggregated monthly metrics and includes FEWSNET baseline series. The phase-change feature must read row-level predictions first, exclude XGB and FEWSNET from the summary, and avoid overwriting standard monthly plots. A dedicated script keeps the exploratory contract isolated while reusing the existing script's layout conventions.
+
+**Alternatives considered**:
+
+- Extend the existing monthly plotter with a phase-change mode: rejected because it would mix row-level and aggregate-metric inputs in one standard diagnostics script.
+- Add a Windows batch launcher: rejected because the feature is exploratory and no full batch workflow is required.
+
+## Decision: Explicitly include GF/GeoRF and DT/GeoDT fs1-fs3 prediction folders
+
+**Rationale**: The inspected source root contains `result_partition_k40_compare_{DT,GF,XGB}_fs{1,2,3}/predictions_monthly.csv`. The spec requires GeoRF and GeoDT only. Explicit model-token mapping reduces accidental inclusion of XGB and gives predictable provenance.
+
+**Alternatives considered**:
+
+- Glob all `predictions_monthly.csv` files and filter later: rejected because it increases the chance of XGB leakage into metric outputs.
+- Require manual file paths only: rejected because the folder naming is already consistent and discoverable.
+
+## Decision: Use previous available test month for phase-change chronology
+
+**Rationale**: The user specified previous available test month, and the inspected monthly outputs contain February, June, and October test months rather than every calendar month. Strict previous calendar month would classify most rows as lacking a predecessor.
+
+**Alternatives considered**:
+
+- Strict previous calendar month: rejected by the feature definition and source cadence.
+- Previous row regardless of sort order: rejected because chronological ordering by `month_start` is required.
+
+## Decision: Treat undefined precision, recall, and F1 as blank/NA
+
+**Rationale**: Undefined metrics caused by zero denominators should not be coerced into false zero or perfect scores. Blank/NA values preserve mathematical meaning, and the manifest records the zero-denominator reason for auditability.
+
+**Alternatives considered**:
+
+- Record undefined values as 0.0: rejected because it conflates undefined with poor performance.
+- Drop the affected month/scope rows: rejected because missingness itself is useful diagnostic evidence.
+
+## Decision: Summary table aggregates by pooling all filtered phase-change rows across months
+
+**Rationale**: The summary table should behave like an overall ablation-style report for each model, scope, and series, while monthly plots show month-by-month variation. Recomputing from pooled filtered rows avoids averaging instability when some months have very small phase-change counts.
+
+**Alternatives considered**:
+
+- Simple average of monthly metrics: rejected because small-sample months would carry the same weight as larger months.
+- Report both pooled and average-monthly metrics: rejected for v1 because the requested table should stay focused and avoid unrelated baseline-style rows.
+
+## Decision: Write generated artifacts under `phase_change_monthly_performance/`
+
+**Rationale**: A new clearly labeled directory under the existing ablation root satisfies the no-overwrite requirement and keeps exploratory outputs near their source data.
+
+**Alternatives considered**:
+
+- Reuse `monthly_performance_plots/`: rejected because it would risk overwriting or confusing standard diagnostics.
+- Write under `deliverables/`: rejected because the feature is exploratory unless explicitly promoted.
+
+## Decision: Produce audit CSVs plus a JSON manifest
+
+**Rationale**: Row-count provenance and filtered-row auditability are central success criteria. A filtered row-level CSV and recomputed monthly metrics CSV make smoke testing and reviewer validation straightforward; a JSON manifest captures included/excluded files, row counts, zero-denominator points, and generated artifacts.
+
+**Alternatives considered**:
+
+- Manifest only: rejected because reviewers may need row-level evidence for phase-change filtering.
+- README only: rejected because machine-readable row counts and missing-metric details are useful for tests.

--- a/specs/003-phase-change-performance/spec.md
+++ b/specs/003-phase-change-performance/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Phase-Change Monthly Performance
+
+**Feature Branch**: `003-phase-change-performance`  
+**Created**: 2026-05-15  
+**Status**: Draft  
+**Input**: User description: "Create a new Spec Kit feature for phase-change-only monthly performance analysis using row-level predictions_monthly.csv outputs for GeoRF and GeoDT only."
+
+## Clarifications
+
+### Session 2026-05-15
+
+- Q: How should undefined precision, recall, or F1 values caused by zero denominators be represented? → A: Record as blank/NA and document the zero-denominator reason in the manifest.
+- Q: How should summary-table metrics aggregate phase-change performance across months? → A: Recompute metrics from all filtered phase-change rows pooled across months for each model, scope, and series.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Identify phase-change prediction rows (Priority: P1)
+
+As a food-crisis model analyst, I need the existing row-level monthly prediction outputs filtered to cases where the true crisis state changed from the same area's previous available test month, so that performance is evaluated on transition cases rather than the full population of stable and changing areas.
+
+**Why this priority**: The phase-change filter is the core value of the feature; plots and tables are only valid if they are derived from the correct row-level subset.
+
+**Independent Test**: Can be tested by loading one GeoRF or GeoDT `predictions_monthly.csv`, selecting one forecasting scope and a small month range, and verifying that rows are retained only when the current `y_true` differs from the previous available `y_true` for the same spatial unit.
+
+**Acceptance Scenarios**:
+
+1. **Given** a GeoRF or GeoDT prediction file with multiple months for the same `FEWSNET_admin_code`, **When** the phase-change filter is applied within one model family and forecasting scope, **Then** the first observed month for each `FEWSNET_admin_code` is excluded and later rows are retained only when `y_true` changes from the immediately previous available test month.
+2. **Given** a spatial unit whose observed test months skip calendar months, **When** the previous value is determined, **Then** the comparison uses the previous available test month in the file, not a strict previous calendar month.
+3. **Given** GeoXGB/XGBoost prediction files under the same source root, **When** source files are selected, **Then** those files are excluded from the analysis and documented as excluded.
+
+---
+
+### User Story 2 - Recompute phase-change monthly metrics (Priority: P2)
+
+As a food-crisis model analyst, I need monthly precision, recall, and F1 recomputed from the filtered phase-change rows for GeoRF and GeoDT, preserving forecasting scopes and pooled versus partitioned result series, so that transition-case performance can be compared to the existing monthly diagnostics.
+
+**Why this priority**: Recomputing from filtered rows avoids misleading results that would occur if already aggregated monthly metrics were filtered or reused.
+
+**Independent Test**: Can be tested by manually calculating precision, recall, and F1 from a filtered month/scope/model subset and confirming the reported metric values match that subset for both pooled and partitioned predictions.
+
+**Acceptance Scenarios**:
+
+1. **Given** filtered phase-change rows for one model family, scope, month, and result series, **When** metrics are calculated, **Then** precision, recall, and F1 are based only on the retained rows for that exact grouping.
+2. **Given** all GeoRF and GeoDT scopes fs1, fs2, and fs3, **When** phase-change metrics are produced, **Then** each scope remains a separate result and is not pooled with other scopes.
+3. **Given** existing monthly metrics files, **When** phase-change metrics are produced, **Then** those aggregate metrics are not used as inputs for the phase-change calculation.
+
+---
+
+### User Story 3 - Produce labeled exploratory outputs (Priority: P3)
+
+As a food-crisis model analyst, I need clearly labeled phase-change-only plots, a summary table in the existing ablation-report style, and a manifest of sources and row counts, so that the outputs can be reviewed without confusing them with standard forecast deliverables or original population-level metrics.
+
+**Why this priority**: The analysis is exploratory and must be traceable, visually comparable, and safely separated from established deliverables.
+
+**Independent Test**: Can be tested by generating the reduced outputs and confirming that all artifact names, labels, and manifest entries state phase-change-only exploratory diagnostics and that no existing standard output directory or file is overwritten.
+
+**Acceptance Scenarios**:
+
+1. **Given** the source ablation root, **When** phase-change outputs are written, **Then** they appear in a new clearly labeled location under `main_ablation_results/march2026_main_backup_month_ind_cont3` and do not overwrite `monthly_performance_plots` or standard forecast deliverables.
+2. **Given** the generated monthly plots, **When** a reviewer opens them, **Then** each plot clearly identifies the analysis as phase-change-only and follows the existing monthly performance layout where practical.
+3. **Given** the generated summary table, **When** a reviewer inspects its rows, **Then** it includes only GeoRF(phase change) and GeoDT(phase change) for fs1, fs2, and fs3, and excludes XGB, FEWSNET, original population-level metrics, and unrelated baseline rows.
+4. **Given** the generated manifest, **When** a reviewer checks provenance, **Then** it lists source files, excluded XGB files, the filter definition, output files, and row counts before and after filtering.
+
+---
+
+### Edge Cases
+
+- If a spatial unit has only one observed test month in a model/scope group, it contributes no phase-change rows because no previous true value exists.
+- If a spatial unit has repeated rows for the same test month within a model/scope group, the analysis must flag the ambiguity in the manifest rather than silently treating duplicates as a normal chronology.
+- If a required prediction column is missing from a selected GeoRF or GeoDT file, the analysis must stop for that file and report the missing contract field.
+- If a filtered month has no retained phase-change rows, the output must mark the month as having no phase-change sample instead of reusing population-level metrics.
+- If precision, recall, or F1 is undefined because the filtered subset has no positive predictions or no positive true labels, the output must record the metric as blank/NA and document the zero-denominator condition in the manifest.
+- If the source root contains additional model folders, only folders matching GeoRF/GF or GeoDT/DT for fs1, fs2, and fs3 are in scope.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The analysis MUST read row-level `predictions_monthly.csv` files from `main_ablation_results/march2026_main_backup_month_ind_cont3` for GeoRF and GeoDT only.
+- **FR-002**: The analysis MUST include exactly the GeoRF/GF and GeoDT/DT forecasting-scope combinations fs1, fs2, and fs3 when their prediction files are present.
+- **FR-003**: The analysis MUST exclude GeoXGB, XGBoost, and XGB-tokened files entirely, and MUST record those exclusions in the manifest or equivalent provenance output.
+- **FR-004**: The analysis MUST treat the inspected source contract as follows: spatial key `FEWSNET_admin_code`; test-month column `month_start`; true crisis indicator `y_true`; predicted crisis indicators `y_pred_pooled` and `y_pred_partitioned`; forecasting scope encoded by the `fs1`, `fs2`, or `fs3` folder suffix; model family encoded by `GF` for GeoRF and `DT` for GeoDT; pooled versus partitioned results encoded by the two prediction columns.
+- **FR-005**: The analysis MUST compute phase-change rows separately within each model family, forecasting scope, prediction file, and spatial key, sorted by `month_start`.
+- **FR-006**: The analysis MUST exclude the first observed test month for each spatial key within each model-family and forecasting-scope group before identifying phase changes.
+- **FR-007**: The analysis MUST define a phase-change row as a row whose current `y_true` differs from the `y_true` for the same spatial key at the immediately previous available test month in that group.
+- **FR-008**: The analysis MUST use previous available test month, not strict previous calendar month, for the phase-change comparison.
+- **FR-009**: The analysis MUST filter row-level predictions first, then recompute monthly class-1 precision, recall, and F1 from the filtered rows.
+- **FR-010**: The analysis MUST NOT filter or reuse already aggregated monthly metrics as the source for phase-change metrics.
+- **FR-011**: The analysis MUST preserve fs1, fs2, and fs3 as separate forecasting scopes throughout filtering, metric calculation, plotting, summary tables, and provenance outputs.
+- **FR-012**: The analysis MUST preserve pooled and partitioned prediction series as separate result series when recomputing metrics and plotting outputs.
+- **FR-013**: The analysis MUST regenerate monthly performance plots using only phase-change rows, following the existing monthly performance plot organization where practical and labeling every plot as phase-change-only.
+- **FR-014**: The analysis MUST create a summary table in the style of `main_ablation_results/Complete_ablation_test_1.xlsx` that includes only GeoRF(phase change) and GeoDT(phase change) for fs1, fs2, and fs3, with metrics recomputed from all filtered phase-change rows pooled across months for each model, scope, and result series.
+- **FR-015**: The analysis MUST NOT include XGB, original population-level metrics, FEWSNET rows, or unrelated baseline rows in the phase-change summary table.
+- **FR-016**: The analysis MUST write outputs to a new clearly labeled location under `main_ablation_results/march2026_main_backup_month_ind_cont3` without overwriting existing `monthly_performance_plots` or standard forecast deliverables.
+- **FR-017**: The analysis MUST produce a short manifest or README documenting source files, excluded files, the filter definition, output files, row counts before and after phase-change filtering for each model family and scope, and any blank/NA metrics caused by zero denominators.
+- **FR-018**: The analysis SHOULD produce filtered row-level audit files when useful for verification, provided they are clearly labeled as phase-change-only exploratory diagnostics.
+- **FR-019**: The analysis MUST support a smoke-test or dry-run path that loads one GeoRF or GeoDT prediction file, selects one forecasting scope and a small set of months, verifies first-row exclusion, reports row counts before and after filtering, recomputes precision/recall/F1, and produces one reduced plot plus one draft summary row.
+- **FR-020**: The feature MUST NOT change ACTIVE_LAGS, temporal lag logic, partition-map semantics, model predictions, model-training workflows, standard three-stage evaluation workflows, fs0-only workflows, standalone prediction workflows, synthetic scenario workflows, or notebook outputs.
+
+### Key Entities *(include if feature involves data)*
+
+- **Prediction Row**: A row-level observation for one spatial unit and test month, containing the true crisis indicator and pooled/partitioned predicted crisis indicators.
+- **Spatial Unit Series**: The ordered sequence of prediction rows for one `FEWSNET_admin_code` within a single model family and forecasting scope.
+- **Phase-Change Row**: A prediction row retained for analysis because its true crisis indicator differs from the same spatial unit's previous available test month.
+- **Monthly Metric Result**: A recomputed precision, recall, and F1 result for one model family, forecasting scope, test month, and result series using only phase-change rows.
+- **Summary Table Row**: A report row for one phase-change model family and forecasting scope in the same broad presentation style as the reference ablation workbook.
+- **Provenance Manifest**: A short audit record describing inputs, exclusions, filter definition, generated artifacts, and row counts before and after filtering.
+
+### Pipeline & Data Assumptions *(mandatory for model/pipeline changes)*
+
+- **Workflow**: Exploratory diagnostics / baseline-comparison analysis. Outputs are exploratory diagnostics unless explicitly promoted later; they are not standard forecasts, fs0-only artifacts, standalone prediction outputs, synthetic scenario overlays, or model-training results.
+- **Temporal Scope**: Existing labeled monthly prediction outputs cover fs1 = 4 months, fs2 = 8 months, and fs3 = 12 months. The inspected files contain 12 existing labeled test/target months from 2021-02-01 through 2024-10-01. This feature analyzes only materialized `month_start` test rows, performs no feature-month-to-target-month remapping, does not alter ACTIVE_LAGS or lag assumptions, and introduces no missing FEWSNET publication handling or synthetic target rows.
+- **Crisis Label**: The binary class-1 crisis label is represented by `y_true`, with values 0 and 1 in the inspected files. Phase-change status is based only on changes in this true label, not on changes in predicted labels.
+- **Spatial Inputs**: The inspected spatial key is `FEWSNET_admin_code`, not `area_id`. Existing `partition_id` values may be retained for audit context but do not define the phase-change grouping. Partition-map identity, k-neighbor graph settings, cluster counts, shapefiles, polygon IDs, and unmapped-polygon fallback behavior are out of scope because predictions already exist.
+- **Geographic Scope**: No map rendering or shapefile joining is in scope. The analysis inherits the geographic coverage of the existing prediction files and must not imply a new shapefile scope.
+- **Threshold Contract**: No new prediction threshold is introduced. The feature analyzes already materialized binary predictions in `y_pred_pooled` and `y_pred_partitioned`; scenario-only thresholds are out of scope.
+- **Prediction Partition Maps**: Partition-map semantics are not changed. The partitioned result series is identified solely from the existing `y_pred_partitioned` column in each source file.
+- **Artifacts**: Expected artifacts are phase-change-only monthly performance plots, a phase-change-only summary table, an optional filtered row-level audit output, and a manifest or README with workflow mode, scope, model family, source files, excluded XGB files, output files, and row-count provenance.
+- **Environment**: This is an incremental analysis on existing repository outputs. It must not require model retraining, full multi-hour batch execution, notebook execution, or a new parallel launcher unless a later implementation plan proves it necessary.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All six in-scope source files are represented in the analysis when present: GeoRF/GF and GeoDT/DT for fs1, fs2, and fs3; all three XGB files under the source root are excluded.
+- **SC-002**: For every included model-family and scope combination, the manifest reports source row counts before filtering, row counts after phase-change filtering, and the count of first observations excluded because no previous true value exists.
+- **SC-003**: For every generated monthly metric value, the calculation can be traced to phase-change-filtered row-level predictions for one model family, one forecasting scope, one test month, and one prediction series.
+- **SC-004**: The monthly plots clearly state phase-change-only analysis and include separate fs1, fs2, and fs3 views for GeoRF and GeoDT where phase-change rows exist.
+- **SC-005**: The summary table contains only GeoRF(phase change) and GeoDT(phase change) rows for fs1, fs2, and fs3, reports metrics recomputed from all filtered phase-change rows pooled across months for each result series, and has no XGB, FEWSNET, original population-level, or unrelated baseline rows.
+- **SC-006**: No files in existing `monthly_performance_plots` or standard forecast deliverable locations are overwritten; all generated outputs are placed in a new clearly labeled phase-change location.
+- **SC-007**: The smoke-test path demonstrates, on one GeoRF or GeoDT configuration and a reduced month set, first-row exclusion, before/after row counts, recomputed precision/recall/F1, one reduced monthly plot, and one draft summary row.
+- **SC-008**: A reviewer can determine the source column contract, filter definition, output location, included models, excluded models, and exploratory status from the generated manifest or README alone.
+
+## Assumptions
+
+- The reference `predictions_monthly.csv` files are the authoritative row-level inputs for this exploratory analysis.
+- `FEWSNET_admin_code` is the effective spatial key because the inspected files do not use an `area_id` column.
+- `month_start` is the effective test-month column and can be ordered chronologically for previous-available-month comparison.
+- The observed prediction files for each included model/scope have the same column contract and comparable month coverage.
+- The broad style of the reference ablation workbook is sufficient; the phase-change table does not need to reproduce unrelated baseline sections that are explicitly out of scope.
+- Optional filtered row-level audit outputs are useful if they make verification easier, but they must remain clearly labeled exploratory diagnostics.

--- a/specs/003-phase-change-performance/tasks.md
+++ b/specs/003-phase-change-performance/tasks.md
@@ -1,0 +1,182 @@
+# Tasks: Phase-Change Monthly Performance
+
+**Input**: Design documents from `/specs/003-phase-change-performance/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/phase-change-analysis-cli.md, quickstart.md
+
+**Tests**: No separate automated test suite was requested. Validation tasks use the required smoke-test, dry-run, and manual artifact checks from quickstart.md.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Every task includes exact file paths
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the dedicated exploratory analysis entry point without touching existing standard outputs.
+
+- [X] T001 Create `scripts/plot_phase_change_monthly_performance.py` with argparse options from `specs/003-phase-change-performance/contracts/phase-change-analysis-cli.md`
+- [X] T002 Define constants for model tokens, scopes, required columns, metric names, output filenames, and default paths in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T003 Add path resolution helpers for relative, absolute, and Windows-style paths in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T004 Add output-directory guard that rejects `main_ablation_results/march2026_main_backup_month_ind_cont3/monthly_performance_plots` in `scripts/plot_phase_change_monthly_performance.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build shared source discovery, validation, and metric primitives that all user stories depend on.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T005 Implement GeoRF/GeoDT source discovery for `main_ablation_results/march2026_main_backup_month_ind_cont3/result_partition_k40_compare_{GF,DT}_fs*/predictions_monthly.csv` in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T006 Implement XGB/GeoXGB exclusion discovery for `main_ablation_results/march2026_main_backup_month_ind_cont3/result_partition_k40_compare_XGB_fs*/predictions_monthly.csv` in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T007 Implement required-column validation for `FEWSNET_admin_code`, `month_start`, `y_true`, `y_pred_pooled`, and `y_pred_partitioned` in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T008 Implement binary-label and date parsing validation for source prediction rows in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T009 Implement precision, recall, and F1 helper calculations with blank/NA output for zero-denominator cases in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T010 Implement manifest data structure for workflow mode, source files, excluded files, column contract, row counts, duplicate flags, zero-denominator metrics, and generated artifacts in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T011 Implement dry-run mode that validates discovery, exclusions, source columns, output path, and planned artifacts without writing files in `scripts/plot_phase_change_monthly_performance.py`
+
+**Checkpoint**: Foundation ready; source files can be discovered and validated without generating final artifacts.
+
+---
+
+## Phase 3: User Story 1 - Identify phase-change prediction rows (Priority: P1) MVP
+
+**Goal**: Filter row-level prediction outputs to rows whose true crisis indicator changed from the previous available test month for the same spatial unit, model, and scope.
+
+**Independent Test**: Run the smoke path on GeoRF fs1 and verify first-observation exclusion, before/after row counts, XGB exclusion, and retained rows where `y_true != previous_y_true`.
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Implement source loading that attaches `model_key`, `model_label`, `source_token`, `scope`, and `source_file` to each row in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T013 [US1] Implement duplicate `(model_key, scope, FEWSNET_admin_code, month_start)` detection and manifest reporting in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T014 [US1] Implement chronological sorting by `month_start` within each `(model_key, scope, FEWSNET_admin_code)` series in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T015 [US1] Implement previous available test-month comparison fields `previous_month_start`, `previous_y_true`, `is_first_observation`, and `phase_change` in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T016 [US1] Implement phase-change row filtering that excludes first observations and retains only rows where `y_true != previous_y_true` in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T017 [US1] Add before-filter, first-observation-excluded, non-change-excluded, and after-filter row counts by model and scope to `phase_change_manifest.json` generation in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T018 [US1] Implement `--model georf --scope fs1 --smoke` validation output for first-row exclusion and phase-change row counts in `scripts/plot_phase_change_monthly_performance.py`
+
+**Checkpoint**: User Story 1 is independently functional and can prove the row-level phase-change filter is correct.
+
+---
+
+## Phase 4: User Story 2 - Recompute phase-change monthly metrics (Priority: P2)
+
+**Goal**: Recompute monthly and summary precision, recall, and F1 from phase-change rows only, preserving fs1-fs3 and pooled versus partitioned result series.
+
+**Independent Test**: Use a filtered month/scope/model subset and confirm the reported precision, recall, and F1 match manual calculations from `y_true`, `y_pred_pooled`, and `y_pred_partitioned`.
+
+### Implementation for User Story 2
+
+- [X] T019 [US2] Implement monthly metric aggregation by `model_key`, `model_label`, `scope`, `month_start`, and series in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T020 [US2] Implement pooled and partitioned series expansion from `y_pred_pooled` and `y_pred_partitioned` in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T021 [US2] Record true-positive, false-positive, false-negative, support, and phase-change row counts for each monthly metric row in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T022 [US2] Record blank/NA precision, recall, or F1 values and zero-denominator reasons in `phase_change_manifest.json` from `scripts/plot_phase_change_monthly_performance.py`
+- [X] T023 [US2] Implement summary-table metric aggregation from all filtered phase-change rows pooled across months for each model, scope, and series in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T024 [US2] Write `metrics_monthly_phase_change.csv` and `summary_phase_change.xlsx` under `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/` from `scripts/plot_phase_change_monthly_performance.py`
+- [X] T025 [US2] Extend `--smoke` output to include one draft summary row and recomputed pooled and partitioned precision, recall, and F1 in `scripts/plot_phase_change_monthly_performance.py`
+
+**Checkpoint**: User Story 2 is independently functional and can prove metrics are recomputed from phase-change rows rather than existing aggregate metrics.
+
+---
+
+## Phase 5: User Story 3 - Produce labeled exploratory outputs (Priority: P3)
+
+**Goal**: Generate clearly labeled phase-change-only plots, tables, audit files, and manifest in a new output directory without overwriting standard diagnostics.
+
+**Independent Test**: Run the full command and verify outputs are in `phase_change_monthly_performance/`, plots and tables are labeled phase-change-only, XGB/FEWSNET are absent from result series, and the manifest documents provenance and row counts.
+
+### Implementation for User Story 3
+
+- [X] T026 [US3] Implement GeoRF and GeoDT phase-change plot rendering using the existing fs1-fs3 by precision/recall/F1 layout in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T027 [US3] Ensure plot titles, legends, axis labels, and filenames identify phase-change-only analysis in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T028 [US3] Exclude FEWSNET and XGB series from phase-change plots and summary outputs in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T029 [US3] Write `filtered_predictions_phase_change.csv` audit output with previous true-value fields under `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/` from `scripts/plot_phase_change_monthly_performance.py`
+- [X] T030 [US3] Honor `--write-audit` behavior so `filtered_predictions_phase_change.csv` is written when audit output is enabled and skipped when disabled in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T031 [US3] Write final `phase_change_manifest.json` with included sources, excluded XGB sources, filter definition, row counts, zero-denominator metrics, duplicate flags, and generated artifacts in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T032 [US3] Ensure full mode writes only to `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/` and never overwrites `main_ablation_results/march2026_main_backup_month_ind_cont3/monthly_performance_plots/` in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T033 [US3] Add concise ASCII-safe console summary for dry-run, smoke, and full modes in `scripts/plot_phase_change_monthly_performance.py`
+- [X] T034 [US3] Implement smoke-mode reduced plot output for `python3 scripts/plot_phase_change_monthly_performance.py --model georf --scope fs1 --smoke` in `scripts/plot_phase_change_monthly_performance.py`
+
+**Checkpoint**: User Story 3 is independently functional and produces traceable exploratory artifacts without touching standard outputs.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate the complete workflow, update usage guidance, and confirm artifact hygiene.
+
+- [X] T035 Run dry-run validation with `python3 scripts/plot_phase_change_monthly_performance.py --dry-run`, inspect console/manifest preview, and verify no generated files are written under `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/`
+- [X] T036 Run smoke validation with `python3 scripts/plot_phase_change_monthly_performance.py --model georf --scope fs1 --smoke` and verify evidence against `specs/003-phase-change-performance/quickstart.md`
+- [X] T037 Capture pre-run timestamps or checksums for files in `main_ablation_results/march2026_main_backup_month_ind_cont3/monthly_performance_plots/` before full exploratory analysis
+- [X] T038 Run full exploratory analysis with `python3 scripts/plot_phase_change_monthly_performance.py` and generate artifacts under `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/`
+- [X] T039 Verify `main_ablation_results/march2026_main_backup_month_ind_cont3/monthly_performance_plots/` was not modified by comparing against the T037 pre-run timestamps or checksums
+- [X] T040 Verify `phase_change_manifest.json` records six included GF/DT source files, XGB exclusions, row counts, zero-denominator metrics, duplicate flags, and generated artifact paths in `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/phase_change_manifest.json`
+- [X] T041 Verify `filtered_predictions_phase_change.csv` rows satisfy `y_true != previous_y_true` and `is_first_observation` is false in `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/filtered_predictions_phase_change.csv`
+- [X] T042 Verify `summary_phase_change.xlsx` contains only GeoRF(phase change) and GeoDT(phase change) rows for fs1, fs2, and fs3 in `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/summary_phase_change.xlsx`
+- [X] T043 Verify `georf_phase_change_monthly_performance.png` and `geodt_phase_change_monthly_performance.png` are clearly labeled phase-change-only in `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/`
+- [X] T044 Update `specs/003-phase-change-performance/quickstart.md` with any final command/output name adjustments discovered during validation
+- [X] T045 Review `git status --short` output to confirm generated phase-change artifacts under `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/` are not accidentally staged unless explicitly promoted
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational completion; MVP phase-change filter.
+- **User Story 2 (Phase 4)**: Depends on User Story 1 filtered rows.
+- **User Story 3 (Phase 5)**: Depends on User Story 2 metrics for final plots/tables.
+- **Polish (Phase 6)**: Depends on all selected user stories being complete.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependency on other stories after Phase 2; delivers MVP row filtering.
+- **User Story 2 (P2)**: Depends on User Story 1 because metrics require filtered rows.
+- **User Story 3 (P3)**: Depends on User Story 2 because final artifacts require recomputed metrics.
+
+### Within Each User Story
+
+- Validate source contracts before filtering.
+- Filter row-level predictions before recomputing metrics.
+- Recompute metrics before rendering plots or summary tables.
+- Run smoke/dry-run validation before full artifact generation.
+- Verify artifact hygiene before considering the feature complete.
+
+## Parallel Execution Examples
+
+No setup or story tasks are currently marked `[P]` because the implementation is intentionally concentrated in `scripts/plot_phase_change_monthly_performance.py`; splitting these tasks across agents would create same-file edit conflicts.
+
+### Validation parallel checks after full generation
+
+```text
+Task: "Verify phase_change_manifest.json records included and excluded sources in main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/phase_change_manifest.json"
+Task: "Verify summary_phase_change.xlsx contains only GeoRF(phase change) and GeoDT(phase change) rows in main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/summary_phase_change.xlsx"
+Task: "Verify georf_phase_change_monthly_performance.png and geodt_phase_change_monthly_performance.png are clearly labeled phase-change-only in main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/"
+```
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 setup for `scripts/plot_phase_change_monthly_performance.py`.
+2. Complete Phase 2 source discovery, validation, metric helper, manifest skeleton, and dry-run support.
+3. Complete Phase 3 row-level phase-change filtering.
+4. Stop and validate with `python3 scripts/plot_phase_change_monthly_performance.py --model georf --scope fs1 --smoke`.
+
+### Incremental Delivery
+
+1. Deliver US1 row filtering and row-count evidence.
+2. Add US2 recomputed monthly and summary metrics.
+3. Add US3 final plots, audit files, manifest, and output isolation.
+4. Complete Phase 6 validation against `specs/003-phase-change-performance/quickstart.md`.
+
+### Artifact Hygiene
+
+- Keep generated artifacts under `main_ablation_results/march2026_main_backup_month_ind_cont3/phase_change_monthly_performance/`.
+- Do not overwrite `main_ablation_results/march2026_main_backup_month_ind_cont3/monthly_performance_plots/`.
+- Do not stage generated CSV, XLSX, PNG, or JSON artifacts unless the user explicitly promotes them as deliverables.


### PR DESCRIPTION
## Summary
- Add a dedicated phase-change-only monthly performance analysis script for GeoRF and GeoDT row-level predictions.
- Generate recomputed phase-change metrics, summary workbook, audit CSV, plots, and manifest in an isolated output directory.
- Add Spec Kit artifacts documenting the CLI contract, data model, validation workflow, and completed implementation tasks.

## Test plan
- [x] python3 -m py_compile scripts/plot_phase_change_monthly_performance.py
- [x] python3 scripts/plot_phase_change_monthly_performance.py --dry-run
- [x] python3 scripts/plot_phase_change_monthly_performance.py --model georf --scope fs1 --smoke
- [x] python3 scripts/plot_phase_change_monthly_performance.py
- [x] Verify monthly_performance_plots checksums unchanged
- [x] Verify manifest, audit CSV, summary workbook, and plot labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)